### PR TITLE
fixed pie chart for relational data (key/groupBy is on another table)

### DIFF
--- a/services/pie-stat-getter.js
+++ b/services/pie-stat-getter.js
@@ -61,7 +61,7 @@ function PieStatGetter(model, params, opts) {
   function getGroupBy() {
     var groupByField;
 
-    if (params['group_by_field'].indexOf('.') === -1) {
+    if (params['group_by_field'].indexOf(':') === -1) {
       groupByField = schema.name + '.' + params['group_by_field'];
     } else {
       groupByField = params['group_by_field'].replace(':', '.');
@@ -73,7 +73,7 @@ function PieStatGetter(model, params, opts) {
     return P.map(records, function (record) {
       var key;
 
-      if (field.type === 'Date') {
+      if (typeof field !== 'undefined' && field.type === 'Date') {
         key = moment(record.key).format('DD/MM/YYYY HH:mm:ss');
       } else {
         key = String(record.key);


### PR DESCRIPTION
This resolves the bug which prevented the use of the pie chart with relational data. Please be aware that field.type will always be undefined as it only checks fields on the originating table. 
Row 11 would need to be adjusted to check all associations, too. But I didn't know how to properly implement that, sorry. So date formatting is not being done in this case. But besides that little thing, it works.