### PR TITLE
Sequelize 4 returns date strings not timestamps so don't shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+- Records Serialization - Prevent DATEONLY fields being serialized to a daty behind in Sequelize 4 where UTC shift is negative
 
 ## RELEASE 1.5.3 - 2017-11-08
 ### Fixed

--- a/services/pie-stat-getter.js
+++ b/services/pie-stat-getter.js
@@ -70,13 +70,17 @@ function PieStatGetter(model, params, opts) {
       [ALIAS_GROUP_BY];
   }
 
+  function isDateOnlyString(field) {
+      return moment(field, 'YYYY-MM-DD', true).isValid();
+  }
+
   function formatResults (records) {
     return P.map(records, function (record) {
       var key;
 
       if (field.type === 'Date') {
         key = moment(record[ALIAS_GROUP_BY]).format('DD/MM/YYYY HH:mm:ss');
-      } else if (field.type === 'Dateonly') {
+      } else if (field.type === 'Dateonly' && !isDateOnlyString(record[ALIAS_GROUP_BY])) {
         var offsetServer = moment().utcOffset() / 60;
         var dateonly = moment.utc(record[ALIAS_GROUP_BY])
           .add(offsetServer, 'h');


### PR DESCRIPTION
As of Sequelize 4 dateonly fields are returned as date strings not
dateTime strings.  Therefore the formatting functionality here will
return incorrect values for dateonly fields in Sequelize 4 if the server
is in a timezone with a negative UTC shift.

Ex: I have 1990-10-02 stored in my DB.  The formatting function will
shift that to 1990-10-01T16:00:00 if I am in PST.  In the UI 01/10/1990
will be shown

sequelize/sequelize#4858

This is the sibling of https://github.com/ForestAdmin/forest-express/pull/123
