### PR TITLE
ResourceCreator should not overwrite associations created by hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Creation - Prevent associations defined while creating a new record from overwriting associations created by hooks [regression introduced in 2.1.1].
 
 ## RELEASE 2.5.3 - 2018-03-07
 ### Changed

--- a/services/resource-creator.js
+++ b/services/resource-creator.js
@@ -29,8 +29,13 @@ function ResourceCreator(model, params) {
         //         have an id.
         if (model.associations) {
           _.forOwn(model.associations, function (association, name) {
-            if (['BelongsToMany', 'HasOne', 'HasMany'].indexOf(association.associationType) > -1) {
-              promisesAfterSave.push(record['set' + _.capitalize(name)](params[name]));
+            if (params[name]) {
+              if (association.associationType === 'HasOne') {
+                promisesAfterSave.push(record['set' + _.capitalize(name)](params[name]));
+              }
+              if (/Many$/.test(association.associationType) && params[name].length) {
+                promisesAfterSave.push(record['add' + _.capitalize(name)](params[name]));
+              }
             }
           });
         }


### PR DESCRIPTION
Consider the following model:
```js
var Order = sequelize.define('Order', { … });
var OrderItem = sequelize.define('OrderItem', { … });

Order.hasMany(OrderItem);
OrderItem.belongsTo(Order);

Order.addHook('afterCreate', (order) => {
  order.addOrderItem({ label: 'Everybody get $10 off!', amount: -10 });
});
```

With the current logic of `ResourceCreator`, when creating a new Order in Forest, the following will happen:
1. the order will be saved
2. the hook will be executed and the order will be associated with the discount item
3. ResourceCreator will execute order.setItems([]) and thus erase the association created by the hook :-(

This patch prevents this behavior. Note that bug is a regression introduced by the latest commit on this file (see 81f7dbe).