### PR TITLE
Prevent includes from queryBuilder to overwrite include from segment scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Smart Segments - Prevent includes from queryBuilder to overwrite include from segment scope.
 
 ## RELEASE 2.7.0 - 2018-03-30
 ### Added

--- a/services/query-builder.js
+++ b/services/query-builder.js
@@ -24,20 +24,24 @@ function QueryBuilder(model, opts, params) {
   };
 
   this.getIncludes = function (modelForIncludes, fieldNamesRequested) {
-    var includes = [];
-    _.values(modelForIncludes.associations).forEach(function (association) {
-      if (!fieldNamesRequested ||
-        (fieldNamesRequested.indexOf(association.as) !== -1)) {
-        if (['HasOne', 'BelongsTo'].indexOf(association.associationType) > -1) {
-          includes.push({
-            model: association.target.unscoped(),
-            as: association.associationAccessor
-          });
-        }
-      }
-    });
-
-    return includes;
+    return _.values(modelForIncludes.associations)
+      .filter(function (association) {
+        return (
+          (!fieldNamesRequested ||
+            fieldNamesRequested.includes(association.as)) &&
+          ['HasOne', 'BelongsTo'].includes(association.associationType) &&
+          // Don't include models that are already included by the segment scope
+          (modelForIncludes._scope.include || []).every(function (include) {
+            return include.model !== association.target
+          })
+        );
+      })
+      .map(function (association) {
+        return {
+          model: association.target.unscoped(),
+          as: association.associationAccessor
+        };
+      });
   };
 
   this.getOrder = function () {

--- a/services/resources-getter.js
+++ b/services/resources-getter.js
@@ -83,16 +83,18 @@ function ResourcesGetter(model, opts, params) {
   }
 
   function getAndCountRecords() {
+    var scoped = segmentScope ? model.scope(segmentScope) : model.unscoped();
     var where = getWhere();
+    var include = queryBuilder.getIncludes(scoped, fieldNamesRequested);
 
     var countOpts = {
-      include: queryBuilder.getIncludes(model, fieldNamesRequested),
-      where: where
+      where: where,
+      include: include
     };
 
     var findAllOpts = {
       where: where,
-      include: queryBuilder.getIncludes(model, fieldNamesRequested),
+      include: include,
       order: queryBuilder.getOrder(),
       offset: queryBuilder.getSkip(),
       limit: queryBuilder.getLimit()
@@ -112,17 +114,10 @@ function ResourcesGetter(model, opts, params) {
       });
     }
 
-    if (segmentScope) {
-      return P.all([
-        model.scope(segmentScope).count(countOpts),
-        model.scope(segmentScope).findAll(findAllOpts)
-      ]);
-    } else {
-      return P.all([
-        model.unscoped().count(countOpts),
-        model.unscoped().findAll(findAllOpts)
-      ]);
-    }
+    return P.all([
+      scoped.count(countOpts),
+      scoped.findAll(findAllOpts)
+    ]);
   }
 
   function getSegment() {


### PR DESCRIPTION
Considering three models `City`, `Region`, `Country`, their associations, and the scope and collection defined as follows:

```js
const City = sequelize.define('City', { … });
const Region = sequelize.define('Region', { … });
const Country = sequelize.define('Country', { … });

City.hasOne(Region);
Region.hasOne(Country);

City.addScope('region+country', {
  include: [{
    model: Region,
    include: [Country]
  }]
});

Liana.collection('City', {
  segments: [{
    name: 'with country',
    scope: 'region+country'
  }]
});
```

When requesting the segment `with country`, the current implementation of resources-getter.js would return the city and the associated region, but not the country associated to that region. This is because `Region` is added automatically to  the `.include` list of the request, and overwrites the `Region` included in the scope.
This patch prevents includes returned by queryBuilder.getIncludes to overwrite the includes of the scope.
