### PR TITLE
[*] Smart Fields - Always pass a Sequelize instance as the first parameter of the Smart Field value getter functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Charts - Fix leaderboard charts on models having several belongsTo targeting the same model.
+- Smart Fields - Always pass a Sequelize instance as the first parameter of the Smart Field value getter functions.
 
 ## RELEASE 2.12.7 - 2018-06-27
 ### Changed

--- a/services/resource-getter.js
+++ b/services/resource-getter.js
@@ -1,5 +1,4 @@
 'use strict';
-var _ = require('lodash');
 var createError = require('http-errors');
 var Interface = require('forest-express');
 var CompositeKeysManager = require('./composite-keys-manager');
@@ -16,18 +15,6 @@ function ResourceGetter(model, params) {
           throw createError(404, 'The ' + model.name + ' #' + params.recordId +
             ' does not exist.');
         }
-
-        // NOTICE: Do not use "toJSON" method to prevent issues on models that
-        //         override this method.
-        record = record.get({ plain: true });
-
-        // Ensure the Serializer set the relationship links on has many
-        // relationships by setting them to an empty array.
-        _.values(model.associations).forEach(function (association) {
-          if (['HasMany', 'BelongsToMany'].indexOf(association.associationType) > -1) {
-            record[association.associationAccessor] = [];
-          }
-        });
 
         if (schema.isCompositePrimary) {
           record.forestCompositePrimary = new CompositeKeysManager(model,


### PR DESCRIPTION
Fix: https://github.com/ForestAdmin/forest-express-sequelize/issues/139

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [ ] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
