### PR TITLE
Fix belongstomany detail view, adding as key in include

### DIFF
--- a/services/has-many-getter.js
+++ b/services/has-many-getter.js
@@ -43,6 +43,7 @@ function HasManyGetter(model, association, opts, params) {
     var associationType;
     var whereAssociation = where || {};
     var foreignKey;
+    var as;
 
     // NOTICE: Detect the association type and foreign key.
     _.values(model.associations).forEach(function (modelAssociation) {
@@ -50,6 +51,7 @@ function HasManyGetter(model, association, opts, params) {
         if (modelAssociation.target.name === association.name) {
           foreignKey = modelAssociation.foreignKey;
           associationType = modelAssociation.associationType;
+          as = modelAssociation.as;
         }
       }
     });
@@ -73,7 +75,7 @@ function HasManyGetter(model, association, opts, params) {
     if (associationType === 'BelongsToMany') {
       var whereForParent = {};
       whereForParent[primaryKeyModel] = params.recordId;
-      countConditions.include = [{ model: model, where: whereForParent }];
+      countConditions.include = [{ model: model, where: whereForParent, as: as }];
     }
 
     return association.count(countConditions);


### PR DESCRIPTION
Initial issue: showing the detail page of an item of a collection having a belongsToMany relationship, the following error occured: 

> Unexpected error: leads is associated to partners using an alias. You must use the 'as' keyword to specify the alias within your include statement.
> SequelizeEagerLoadingError: leads is associated to partners using an alias. You must use the 'as' keyword to specify the alias within your include statement.

As suggested by the error text, I added the "as" in the include statement.

_Note: I am not a pro dev, hence this fix works for me but probably is not the cleanest implementation, nor has it been extensively tested!_
