### PR TITLE
[*] Technical - Remove cognitive complexity in query-builder service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Changed
 - Technical - Upgrade to babel 7 stable.
 
+### Fixed
+- Technical - Remove cognitive complexity in query-builder service.
+
 ## RELEASE 5.7.0 - 2020-01-22
 ### Added
 - Has Many Relationships - Enable sorting on belongsTo relationship columns in related data.

--- a/src/services/query-builder.js
+++ b/src/services/query-builder.js
@@ -44,45 +44,43 @@ function QueryBuilder(model, opts, params) {
   };
 
   this.getOrder = (aliasName, aliasSchema) => {
-    if (params.sort) {
-      let order = 'ASC';
+    if (!params.sort) { return null; }
 
-      if (params.sort[0] === '-') {
-        params.sort = params.sort.substring(1);
-        order = 'DESC';
-      }
+    let order = 'ASC';
 
-      // NOTICE: Sequelize version previous to 4.4.2 generate a bad MSSQL query
-      //         if users sort the collection on the primary key, so we prevent
-      //         that.
-      const idField = _.keys(model.primaryKeys)[0];
-      if (Database.isMSSQL(opts) && _.includes([idField, `-${idField}`], params.sort)) {
-        const sequelizeVersion = opts.sequelize.version;
-        if (sequelizeVersion !== '4.4.2-forest') {
-          return null;
-        }
-      }
-
-      if (params.sort.indexOf('.') !== -1) {
-        // NOTICE: Sort on the belongsTo displayed field
-        const sortingParameters = params.sort.split('.');
-        const associationName = aliasName ? `${aliasName}->${sortingParameters[0]}` : sortingParameters[0];
-        const fieldName = sortingParameters[1];
-        const column = getReferenceField(
-          Schemas.schemas,
-          (aliasSchema || schema),
-          associationName,
-          fieldName,
-        );
-        return [[opts.sequelize.col(column), order]];
-      }
-      if (aliasName) {
-        return [[opts.sequelize.col(`${aliasName}.${Orm.getColumnName(aliasSchema, params.sort)}`), order]];
-      }
-      return [[params.sort, order]];
+    if (params.sort[0] === '-') {
+      params.sort = params.sort.substring(1);
+      order = 'DESC';
     }
 
-    return null;
+    // NOTICE: Sequelize version previous to 4.4.2 generate a bad MSSQL query
+    //         if users sort the collection on the primary key, so we prevent
+    //         that.
+    const idField = _.keys(model.primaryKeys)[0];
+    if (Database.isMSSQL(opts) && _.includes([idField, `-${idField}`], params.sort)) {
+      const sequelizeVersion = opts.sequelize.version;
+      if (sequelizeVersion !== '4.4.2-forest') {
+        return null;
+      }
+    }
+
+    if (params.sort.indexOf('.') !== -1) {
+      // NOTICE: Sort on the belongsTo displayed field
+      const sortingParameters = params.sort.split('.');
+      const associationName = aliasName ? `${aliasName}->${sortingParameters[0]}` : sortingParameters[0];
+      const fieldName = sortingParameters[1];
+      const column = getReferenceField(
+        Schemas.schemas,
+        (aliasSchema || schema),
+        associationName,
+        fieldName,
+      );
+      return [[opts.sequelize.col(column), order]];
+    }
+    if (aliasName) {
+      return [[opts.sequelize.col(`${aliasName}.${Orm.getColumnName(aliasSchema, params.sort)}`), order]];
+    }
+    return [[params.sort, order]];
   };
 }
 


### PR DESCRIPTION
Remove this warning by using the [return early pattern](http://www.itamarweiss.com/personal/2018/02/28/return-early-pattern.html): 

> 46:44  warning  Refactor this function to reduce its Cognitive Complexity from 17 to the 15 allowed  sonarjs/cognitive-complexity

(hide whitespace, there are only a few changes)