### PR TITLE
[*] Technical - Remove cognitive complexity in pie-stat-getter service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Changed
 - Technical - Upgrade to babel 7 stable.
 
+### Fixed
+- Technical - Remove cognitive complexity in pie-stat-getter service.
+
 ## RELEASE 5.7.0 - 2020-01-22
 ### Added
 - Has Many Relationships - Enable sorting on belongsTo relationship columns in related data.


### PR DESCRIPTION
Fix:

> /Users/raphaelh/web/forest-express-sequelize/src/services/pie-stat-getter.js
  13:10  warning  Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed  sonarjs/cognitive-complexity

Todo: 
 - [ ] self review
 - [ ] add tests