### PR TITLE
[+] Resources Remover - Add resources remover (bulk destroy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Technical - Add optional chaining plugin to babel.
 - Tests - Add MySQL min (5.6) and max (8.0) versions.
 - Database Support - Add support for MySQL 8.
-- Resources Remover - Add resources remover (bulk destroy).
+- Resource Deletion - Users can now bulk delete records.
 
 ### Changed
 - Technical - Upgrade to babel 7 stable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Technical - Add optional chaining plugin to babel.
 - Tests - Add MySQL min (5.6) and max (8.0) versions.
 - Database Support - Add support for MySQL 8.
+- Resources Remover - Add resources remover (bulk destroy).
 
 ### Changed
 - Technical - Upgrade to babel 7 stable.

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const ResourceCreator = require('./services/resource-creator');
 const ResourceUpdater = require('./services/resource-updater');
 const ResourceRemover = require('./services/resource-remover');
 const ResourcesExporter = require('./services/resources-exporter');
+const ResourcesRemover = require('./services/resources-remover');
 
 const HasManyGetter = require('./services/has-many-getter');
 const HasManyAssociator = require('./services/has-many-associator');
@@ -117,6 +118,7 @@ exports.init = function init(opts) {
   exports.ResourceCreator = ResourceCreator;
   exports.ResourceUpdater = ResourceUpdater;
   exports.ResourceRemover = ResourceRemover;
+  exports.ResourcesRemover = ResourcesRemover;
   exports.ResourcesExporter = ResourcesExporter;
 
   exports.HasManyGetter = HasManyGetter;

--- a/src/index.js
+++ b/src/index.js
@@ -118,8 +118,8 @@ exports.init = function init(opts) {
   exports.ResourceCreator = ResourceCreator;
   exports.ResourceUpdater = ResourceUpdater;
   exports.ResourceRemover = ResourceRemover;
-  exports.ResourcesRemover = ResourcesRemover;
   exports.ResourcesExporter = ResourcesExporter;
+  exports.ResourcesRemover = ResourcesRemover;
 
   exports.HasManyGetter = HasManyGetter;
   exports.HasManyAssociator = HasManyAssociator;

--- a/src/services/composite-keys-manager.js
+++ b/src/services/composite-keys-manager.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 function CompositeKeysManager(model, schema, record) {
   const GLUE = '-';
 
-  this.getRecordConditions = function getRecordConditions(recordId) {
-    const where = {};
+  this.getPrimaryKeyValues = function getPrimaryKeyValues(recordId) {
     const primaryKeyValues = recordId.split(GLUE);
 
     // NOTICE: Prevent liana to crash when a composite primary keys is null,
@@ -12,6 +11,22 @@ function CompositeKeysManager(model, schema, record) {
     primaryKeyValues.forEach((key, index) => {
       if (key === 'null') { primaryKeyValues[index] = null; }
     });
+
+    return primaryKeyValues;
+  };
+
+  this.getRecordsConditions = function getRecordsConditions(recordsIds) {
+    return recordsIds.reduce((where, recordId) => {
+      Object.entries(this.getRecordConditions(recordId)).forEach(([key, value]) => {
+        where[key] = [...(where[key] || []), value];
+      });
+      return where;
+    }, {});
+  };
+
+  this.getRecordConditions = function getRecordConditions(recordId) {
+    const where = {};
+    const primaryKeyValues = this.getPrimaryKeyValues(recordId);
 
     if (primaryKeyValues.length === _.keys(model.primaryKeys).length) {
       _.keys(model.primaryKeys).forEach((primaryKey, index) => {

--- a/src/services/composite-keys-manager.js
+++ b/src/services/composite-keys-manager.js
@@ -27,7 +27,6 @@ function CompositeKeysManager(model, schema, record) {
   this.getRecordConditions = function getRecordConditions(recordId) {
     const where = {};
     const primaryKeyValues = this.getPrimaryKeyValues(recordId);
-
     if (primaryKeyValues.length === _.keys(model.primaryKeys).length) {
       _.keys(model.primaryKeys).forEach((primaryKey, index) => {
         where[primaryKey] = primaryKeyValues[index];

--- a/src/services/composite-keys-manager.js
+++ b/src/services/composite-keys-manager.js
@@ -1,4 +1,5 @@
-const _ = require('lodash');
+import _ from 'lodash';
+import Operators from '../utils/operators';
 
 function CompositeKeysManager(model, schema, record) {
   const GLUE = '-';
@@ -15,13 +16,9 @@ function CompositeKeysManager(model, schema, record) {
     return primaryKeyValues;
   };
 
-  this.getRecordsConditions = function getRecordsConditions(recordsIds) {
-    return recordsIds.reduce((where, recordId) => {
-      Object.entries(this.getRecordConditions(recordId)).forEach(([key, value]) => {
-        where[key] = [...(where[key] || []), value];
-      });
-      return where;
-    }, {});
+  this.getRecordsConditions = function getRecordsConditions(recordsIds, options) {
+    const { OR } = new Operators(options);
+    return { [OR]: recordsIds.map((recordId) => this.getRecordConditions(recordId)) };
   };
 
   this.getRecordConditions = function getRecordConditions(recordId) {

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -14,5 +14,14 @@ function NoMatchingOperatorError(message) {
 }
 NoMatchingOperatorError.prototype = new Error();
 
+function InvalidParameterError(message) {
+  this.name = 'InvalidParameterError';
+  this.message = message || 'The given parameter is invalid.';
+  this.status = 422;
+  this.stack = (new Error()).stack;
+}
+InvalidParameterError.prototype = new Error();
+
 exports.ErrorHTTP422 = ErrorHTTP422;
 exports.NoMatchingOperatorError = NoMatchingOperatorError;
+exports.InvalidParameterError = InvalidParameterError;

--- a/src/services/resources-remover.js
+++ b/src/services/resources-remover.js
@@ -1,0 +1,20 @@
+const Interface = require('forest-express');
+const CompositeKeysManager = require('./composite-keys-manager');
+const { InvalidParameterError } = require('./errors');
+
+function ResourcesRemover(model, ids) {
+  this.perform = () => {
+    if (!Array.isArray(ids) || !ids.length) {
+      throw new InvalidParameterError('`ids` must be an array.');
+    }
+
+    const schema = Interface.Schemas.schemas[model.name];
+    const compositeKeysManager = new CompositeKeysManager(model);
+    const where = schema.isCompositePrimary
+      ? compositeKeysManager.getRecordsConditions(ids) : { [schema.idField]: ids };
+
+    return model.destroy({ where });
+  };
+}
+
+module.exports = ResourcesRemover;

--- a/src/services/resources-remover.js
+++ b/src/services/resources-remover.js
@@ -5,7 +5,7 @@ const { InvalidParameterError } = require('./errors');
 function ResourcesRemover(model, ids) {
   this.perform = () => {
     if (!Array.isArray(ids) || !ids.length) {
-      throw new InvalidParameterError('`ids` must be an array.');
+      throw new InvalidParameterError('`ids` must be a non-empty array.');
     }
 
     const schema = Interface.Schemas.schemas[model.name];

--- a/src/services/resources-remover.js
+++ b/src/services/resources-remover.js
@@ -2,7 +2,7 @@ const Interface = require('forest-express');
 const CompositeKeysManager = require('./composite-keys-manager');
 const { InvalidParameterError } = require('./errors');
 
-function ResourcesRemover(model, ids) {
+function ResourcesRemover(model, ids, options) {
   this.perform = () => {
     if (!Array.isArray(ids) || !ids.length) {
       throw new InvalidParameterError('`ids` must be a non-empty array.');
@@ -11,7 +11,7 @@ function ResourcesRemover(model, ids) {
     const schema = Interface.Schemas.schemas[model.name];
     const compositeKeysManager = new CompositeKeysManager(model);
     const where = schema.isCompositePrimary
-      ? compositeKeysManager.getRecordsConditions(ids) : { [schema.idField]: ids };
+      ? compositeKeysManager.getRecordsConditions(ids, options) : { [schema.idField]: ids };
 
     return model.destroy({ where });
   };

--- a/test/services/composite-keys-manager.test.js
+++ b/test/services/composite-keys-manager.test.js
@@ -1,0 +1,76 @@
+import ComppositeKeyManager from '../../src/services/composite-keys-manager';
+
+describe('services > composite-keys-manager', () => {
+  describe('getPrimaryKeyValues', () => {
+    const compositeKeyManager = new ComppositeKeyManager();
+    it('should return one value for non composite key', () => {
+      expect.assertions(1);
+      const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1');
+      expect(primaryKeyValues).toStrictEqual(['1']);
+    });
+    it('should return two values for composite key string with two values', () => {
+      expect.assertions(1);
+      const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1-2');
+      expect(primaryKeyValues).toStrictEqual(['1', '2']);
+    });
+    it('should return null if `null` string is present', () => {
+      expect.assertions(1);
+      const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1-null');
+      expect(primaryKeyValues).toStrictEqual(['1', null]);
+    });
+  });
+
+  describe('getRecordConditions', () => {
+    it('should return a where condition with one key for non composite key', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { id: {} } };
+      const compositeKeyManager = new ComppositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordConditions('1');
+      expect(conditions).toStrictEqual({ id: '1' });
+    });
+    it('should return a where condition with two keys for composite key', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { actorId: {}, filmId: {} } };
+      const compositeKeyManager = new ComppositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordConditions('1-2');
+      expect(conditions).toStrictEqual({ actorId: '1', filmId: '2' });
+    });
+  });
+
+  describe('getRecordsConditions', () => {
+    it('should return a where condition with one key for non composite key', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { actorId: {} } };
+      const compositeKeyManager = new ComppositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordsConditions(['1', '2']);
+      expect(conditions).toStrictEqual({ actorId: ['1', '2'] });
+    });
+    it('should return a where condition with two keys for composite key', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { actorId: {}, filmId: {} } };
+      const compositeKeyManager = new ComppositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordsConditions(['1-2', '3-4']);
+      expect(conditions).toStrictEqual({ actorId: ['1', '3'], filmId: ['2', '4'] });
+    });
+  });
+
+  describe('createCompositePrimary', () => {
+    it('should create a simple key for non composite record', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { actorId: {} } };
+      const record = { actorId: '1' };
+      const compositeKeyManager = new ComppositeKeyManager(model, null, record);
+      const compositePrimary = compositeKeyManager.createCompositePrimary();
+      expect(compositePrimary).toStrictEqual('1');
+    });
+
+    it('should create a composite key for composite record', () => {
+      expect.assertions(1);
+      const model = { primaryKeys: { actorId: {}, filmId: {} } };
+      const record = { actorId: '1', filmId: '2' };
+      const compositeKeyManager = new ComppositeKeyManager(model, null, record);
+      const compositePrimary = compositeKeyManager.createCompositePrimary();
+      expect(compositePrimary).toStrictEqual('1-2');
+    });
+  });
+});

--- a/test/services/composite-keys-manager.test.js
+++ b/test/services/composite-keys-manager.test.js
@@ -1,8 +1,9 @@
-import ComppositeKeyManager from '../../src/services/composite-keys-manager';
+import Sequelize, { Op } from 'sequelize';
+import CompositeKeyManager from '../../src/services/composite-keys-manager';
 
 describe('services > composite-keys-manager', () => {
   describe('getPrimaryKeyValues', () => {
-    const compositeKeyManager = new ComppositeKeyManager();
+    const compositeKeyManager = new CompositeKeyManager();
     it('should return one value for non composite key', () => {
       expect.assertions(1);
       const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1');
@@ -24,33 +25,34 @@ describe('services > composite-keys-manager', () => {
     it('should return a where condition with one key for non composite key', () => {
       expect.assertions(1);
       const model = { primaryKeys: { id: {} } };
-      const compositeKeyManager = new ComppositeKeyManager(model);
+      const compositeKeyManager = new CompositeKeyManager(model);
       const conditions = compositeKeyManager.getRecordConditions('1');
       expect(conditions).toStrictEqual({ id: '1' });
     });
     it('should return a where condition with two keys for composite key', () => {
       expect.assertions(1);
       const model = { primaryKeys: { actorId: {}, filmId: {} } };
-      const compositeKeyManager = new ComppositeKeyManager(model);
+      const compositeKeyManager = new CompositeKeyManager(model);
       const conditions = compositeKeyManager.getRecordConditions('1-2');
       expect(conditions).toStrictEqual({ actorId: '1', filmId: '2' });
     });
   });
 
   describe('getRecordsConditions', () => {
+    const sequelizeOptions = { sequelize: Sequelize };
     it('should return a where condition with one key for non composite key', () => {
       expect.assertions(1);
       const model = { primaryKeys: { actorId: {} } };
-      const compositeKeyManager = new ComppositeKeyManager(model);
-      const conditions = compositeKeyManager.getRecordsConditions(['1', '2']);
-      expect(conditions).toStrictEqual({ actorId: ['1', '2'] });
+      const compositeKeyManager = new CompositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordsConditions(['1', '2'], sequelizeOptions);
+      expect(conditions).toStrictEqual({ [Op.or]: [{ actorId: '1' }, { actorId: '2' }] });
     });
     it('should return a where condition with two keys for composite key', () => {
       expect.assertions(1);
       const model = { primaryKeys: { actorId: {}, filmId: {} } };
-      const compositeKeyManager = new ComppositeKeyManager(model);
-      const conditions = compositeKeyManager.getRecordsConditions(['1-2', '3-4']);
-      expect(conditions).toStrictEqual({ actorId: ['1', '3'], filmId: ['2', '4'] });
+      const compositeKeyManager = new CompositeKeyManager(model);
+      const conditions = compositeKeyManager.getRecordsConditions(['1-2', '3-4'], sequelizeOptions);
+      expect(conditions).toStrictEqual({ [Op.or]: [{ actorId: '1', filmId: '2' }, { actorId: '3', filmId: '4' }] });
     });
   });
 
@@ -59,7 +61,7 @@ describe('services > composite-keys-manager', () => {
       expect.assertions(1);
       const model = { primaryKeys: { actorId: {} } };
       const record = { actorId: '1' };
-      const compositeKeyManager = new ComppositeKeyManager(model, null, record);
+      const compositeKeyManager = new CompositeKeyManager(model, null, record);
       const compositePrimary = compositeKeyManager.createCompositePrimary();
       expect(compositePrimary).toStrictEqual('1');
     });
@@ -68,7 +70,7 @@ describe('services > composite-keys-manager', () => {
       expect.assertions(1);
       const model = { primaryKeys: { actorId: {}, filmId: {} } };
       const record = { actorId: '1', filmId: '2' };
-      const compositeKeyManager = new ComppositeKeyManager(model, null, record);
+      const compositeKeyManager = new CompositeKeyManager(model, null, record);
       const compositePrimary = compositeKeyManager.createCompositePrimary();
       expect(compositePrimary).toStrictEqual('1-2');
     });

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -35,7 +35,7 @@ describe('services > resources-remover', () => {
             where: {
               [Op.or]: [
                 { actorId: '1', filmId: '2' },
-                { actorId: '3', filmId: '4' }
+                { actorId: '3', filmId: '4' },
               ],
             },
           });

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -11,7 +11,7 @@ describe('services > resources-remover', () => {
       expect(() => new ResourcesRemover(null, {}).perform()).toThrow(InvalidParameterError);
     });
 
-    it('should remove resources with simple keys', async () => {
+    it('should remove resources with a single primary key', async () => {
       expect.assertions(1);
       function Actor() {
         this.name = 'actor';

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -35,7 +35,8 @@ describe('services > resources-remover', () => {
             where: {
               [Op.or]: [
                 { actorId: '1', filmId: '2' },
-                { actorId: '3', filmId: '4' }],
+                { actorId: '3', filmId: '4' }
+              ],
             },
           });
         };

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -1,14 +1,14 @@
 import Interface from 'forest-express';
-import RessourcesRemover from '../../src/services/resources-remover';
+import ResourcesRemover from '../../src/services/resources-remover';
 import { InvalidParameterError } from '../../src/services/errors';
 
 describe('services > resources-remover', () => {
   describe('perform', () => {
     it('should throw error if ids is not an array or empty', () => {
       expect.assertions(3);
-      expect(() => new RessourcesRemover(null, []).perform()).toThrow(InvalidParameterError);
-      expect(() => new RessourcesRemover(null, 'foo').perform()).toThrow(InvalidParameterError);
-      expect(() => new RessourcesRemover(null, {}).perform()).toThrow(InvalidParameterError);
+      expect(() => new ResourcesRemover(null, []).perform()).toThrow(InvalidParameterError);
+      expect(() => new ResourcesRemover(null, 'foo').perform()).toThrow(InvalidParameterError);
+      expect(() => new ResourcesRemover(null, {}).perform()).toThrow(InvalidParameterError);
     });
 
     it('should remove resources with simple keys', async () => {
@@ -21,7 +21,7 @@ describe('services > resources-remover', () => {
         };
       }
       Interface.Schemas = { schemas: { actor: { idField: 'id' } } };
-      await new RessourcesRemover(new Actor(), ['1', '2']).perform();
+      await new ResourcesRemover(new Actor(), ['1', '2']).perform();
     });
 
     it('should remove resources with composite keys', async () => {
@@ -41,7 +41,7 @@ describe('services > resources-remover', () => {
           },
         },
       };
-      await new RessourcesRemover(new ActorFilm(), ['1-2', '3-4']).perform();
+      await new ResourcesRemover(new ActorFilm(), ['1-2', '3-4']).perform();
     });
   });
 });

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -1,4 +1,5 @@
 import Interface from 'forest-express';
+import Sequelize, { Op } from 'sequelize';
 import ResourcesRemover from '../../src/services/resources-remover';
 import { InvalidParameterError } from '../../src/services/errors';
 
@@ -30,7 +31,13 @@ describe('services > resources-remover', () => {
         this.name = 'actorFilm';
         this.primaryKeys = { actorId: {}, filmId: {} };
         this.destroy = (condition) => {
-          expect(condition).toStrictEqual({ where: { actorId: ['1', '3'], filmId: ['2', '4'] } });
+          expect(condition).toStrictEqual({
+            where: {
+              [Op.or]: [
+                { actorId: '1', filmId: '2' },
+                { actorId: '3', filmId: '4' }],
+            },
+          });
         };
       }
       Interface.Schemas = {
@@ -41,7 +48,8 @@ describe('services > resources-remover', () => {
           },
         },
       };
-      await new ResourcesRemover(new ActorFilm(), ['1-2', '3-4']).perform();
+      const sequelizeOptions = { sequelize: Sequelize };
+      await new ResourcesRemover(new ActorFilm(), ['1-2', '3-4'], sequelizeOptions).perform();
     });
   });
 });

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -1,0 +1,47 @@
+import Interface from 'forest-express';
+import RessourcesRemover from '../../src/services/resources-remover';
+import { InvalidParameterError } from '../../src/services/errors';
+
+describe('services > resources-remover', () => {
+  describe('perform', () => {
+    it('should throw error if ids is not an array or empty', () => {
+      expect.assertions(3);
+      expect(() => new RessourcesRemover(null, []).perform()).toThrow(InvalidParameterError);
+      expect(() => new RessourcesRemover(null, 'foo').perform()).toThrow(InvalidParameterError);
+      expect(() => new RessourcesRemover(null, {}).perform()).toThrow(InvalidParameterError);
+    });
+
+    it('should remove resources with simple keys', async () => {
+      expect.assertions(1);
+      function Actor() {
+        this.name = 'actor';
+        this.primaryKeys = { id: {} };
+        this.destroy = (condition) => {
+          expect(condition).toStrictEqual({ where: { id: ['1', '2'] } });
+        };
+      }
+      Interface.Schemas = { schemas: { actor: { idField: 'id' } } };
+      await new RessourcesRemover(new Actor(), ['1', '2']).perform();
+    });
+
+    it('should remove resources with composite keys', async () => {
+      expect.assertions(1);
+      function ActorFilm() {
+        this.name = 'actorFilm';
+        this.primaryKeys = { actorId: {}, filmId: {} };
+        this.destroy = (condition) => {
+          expect(condition).toStrictEqual({ where: { actorId: ['1', '3'], filmId: ['2', '4'] } });
+        };
+      }
+      Interface.Schemas = {
+        schemas: {
+          actorFilm: {
+            isCompositePrimary: true,
+            primaryKeys: ['actorId', 'filmId'],
+          },
+        },
+      };
+      await new RessourcesRemover(new ActorFilm(), ['1-2', '3-4']).perform();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Deleting multiple records 1 by 1 seems instable (it fails with 5000 records for @jeffladiray) and is slow. This PR adds a new `RecordsRemover` that handles bulk destroy.

Required by: https://github.com/ForestAdmin/forest-express/pull/346

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
