### PR TITLE
fix mistreatment of records that contain a column named 'length'

### DIFF
--- a/src/services/resource-updater.js
+++ b/src/services/resource-updater.js
@@ -15,7 +15,7 @@ function ResourceUpdater(model, params, newRecord) {
       .perform()
       .then((record) => {
         if (record) {
-          _.each(newRecord, (value, attribute) => {
+          _.forIn(newRecord, (value, attribute) => {
             record[attribute] = value;
           });
 


### PR DESCRIPTION
`_.each` can iterate over both objects and collections, but if an object has a `length` key, it will be treated as an array. This PR resolves this issue by replacing `_.each` with `_.forIn` which is more appropriate for objects.

Source: https://lodash.com/docs/4.17.15#forEach

A better approach could be to just use `Object.assign` and ditch the iteration altogether. Let me know what's your take.
