### PR TITLE
fix: parse uuid composite key correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Composite Key - Composite keys using UUID are now properly parsed.
 
 ## RELEASE 6.1.0 - 2020-04-17
 ### Changed

--- a/src/services/composite-keys-manager.js
+++ b/src/services/composite-keys-manager.js
@@ -1,12 +1,21 @@
 import _ from 'lodash';
 import Operators from '../utils/operators';
 
+const REGEX_UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g;
+
 function CompositeKeysManager(model, schema, record) {
   const GLUE = '-';
 
   this.getPrimaryKeyValues = function getPrimaryKeyValues(recordId) {
-    const primaryKeyValues = recordId.split(GLUE);
+    let primaryKeyValues = recordId.split(GLUE);
 
+    // NOTICE: In the specific case of a composite primary key using UUID,
+    //         this key would contains the GLUE character in its definition,
+    //         Instead of just splitting, all the keys can be retrieved
+    //         be directly searching UUID
+    if (model && primaryKeyValues.length !== _.keys(model.primaryKeys).length) {
+      primaryKeyValues = recordId.match(REGEX_UUID);
+    }
     // NOTICE: Prevent liana to crash when a composite primary keys is null,
     //         this behaviour should be avoid instead of fixed.
     primaryKeyValues.forEach((key, index) => {

--- a/src/services/composite-keys-manager.js
+++ b/src/services/composite-keys-manager.js
@@ -8,14 +8,17 @@ function CompositeKeysManager(model, schema, record) {
 
   this.getPrimaryKeyValues = function getPrimaryKeyValues(recordId) {
     let primaryKeyValues = recordId.split(GLUE);
+    const modelPrimaryKeys = model && model.primaryKeys ? _.keys(model.primaryKeys) : [];
+    const primaryKeyValuesMatchingUUID = recordId.match(REGEX_UUID) || [];
 
-    // NOTICE: In the specific case of a composite primary key using UUID,
-    //         this key would contains the GLUE character in its definition,
-    //         Instead of just splitting, all the keys can be retrieved
-    //         be directly searching UUID
-    if (model && primaryKeyValues.length !== _.keys(model.primaryKeys).length) {
-      primaryKeyValues = recordId.match(REGEX_UUID);
+    // NOTICE: When composite key use UUID, `.split(GLUE)` will not match the
+    //         expected number of primary keys. In that specific case, a UUID
+    //         regex should be enough to retrieve the composite keys.
+    if (modelPrimaryKeys.length !== primaryKeyValues.length
+      && modelPrimaryKeys.length === primaryKeyValuesMatchingUUID.length) {
+      primaryKeyValues = primaryKeyValuesMatchingUUID;
     }
+
     // NOTICE: Prevent liana to crash when a composite primary keys is null,
     //         this behaviour should be avoid instead of fixed.
     primaryKeyValues.forEach((key, index) => {

--- a/test/services/composite-keys-manager.test.js
+++ b/test/services/composite-keys-manager.test.js
@@ -3,7 +3,8 @@ import CompositeKeyManager from '../../src/services/composite-keys-manager';
 
 describe('services > composite-keys-manager', () => {
   describe('getPrimaryKeyValues', () => {
-    const compositeKeyManager = new CompositeKeyManager();
+    const model = { primaryKeys: { actorId: {}, filmId: {} } };
+    const compositeKeyManager = new CompositeKeyManager(model);
     it('should return one value for non composite key', () => {
       expect.assertions(1);
       const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1');
@@ -21,7 +22,7 @@ describe('services > composite-keys-manager', () => {
     });
     it('should return a list of UUID for composite key composed with UUID', () => {
       expect.assertions(1);
-      const primaryKeyValues = new CompositeKeyManager({ primaryKeys: ['a', 'b'] }).getPrimaryKeyValues('004ad17a-8304-11ea-9ba9-0242ac110002-131e2a9a-8304-11ea-9ba9-0242ac110002');
+      const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('004ad17a-8304-11ea-9ba9-0242ac110002-131e2a9a-8304-11ea-9ba9-0242ac110002');
       expect(primaryKeyValues).toStrictEqual(['004ad17a-8304-11ea-9ba9-0242ac110002', '131e2a9a-8304-11ea-9ba9-0242ac110002']);
     });
   });

--- a/test/services/composite-keys-manager.test.js
+++ b/test/services/composite-keys-manager.test.js
@@ -19,6 +19,11 @@ describe('services > composite-keys-manager', () => {
       const primaryKeyValues = compositeKeyManager.getPrimaryKeyValues('1-null');
       expect(primaryKeyValues).toStrictEqual(['1', null]);
     });
+    it('should return a list of UUID for composite key composed with UUID', () => {
+      expect.assertions(1);
+      const primaryKeyValues = new CompositeKeyManager({ primaryKeys: ['a', 'b'] }).getPrimaryKeyValues('004ad17a-8304-11ea-9ba9-0242ac110002-131e2a9a-8304-11ea-9ba9-0242ac110002');
+      expect(primaryKeyValues).toStrictEqual(['004ad17a-8304-11ea-9ba9-0242ac110002', '131e2a9a-8304-11ea-9ba9-0242ac110002']);
+    });
   });
 
   describe('getRecordConditions', () => {


### PR DESCRIPTION
https://app.clickup.com/t/4pmryd

It would have been better to check for the `DataTypes` of the keys composing the composite keys. But since `ResourceGetter` does not have the `options.sequelize`, I cannot compare the `DataTypes` of the primary keys to `UUID` (And I didn't find an "easy" way to pass `sequelize.DataTypes` without generating loads of changes in ResourceGetter/Finder calls).
Because of that, and since that seems to be the first issue related to this part of code, I think this fix is "ok" for now.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Write changes made in the CHANGELOG.md
- [x] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
