### PR TITLE
test: remove useless assertion that is not in a test

### DIFF
--- a/test/services/filters-parser.test.js
+++ b/test/services/filters-parser.test.js
@@ -207,7 +207,6 @@ describe('services > filters-parser', () => {
   describe('getPreviousIntervalCondition function', () => {
     describe('working scenarii', () => {
       describe('with \'and\' aggregator + flat conditions + 1 previous interval', () => {
-        expect.assertions(1);
         const aggregator = JSON.stringify({
           aggregator: 'and',
           conditions: [defaultCondition, defaultCondition2, defaultDateCondition],


### PR DESCRIPTION
This expectation is not at the right place in the tests, it is not in a test but in a `describe` section, and it fails when launching jest on a given test (when developing).

The only test in the section already has the same declaration, that's why I just removed this line.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
