### PR TITLE
Feature - added support for MySQL IN operator

### DIFF
--- a/src/services/filters-parser.js
+++ b/src/services/filters-parser.js
@@ -65,6 +65,8 @@ function FiltersParser(modelSchema, timezone, options) {
       case 'blank':
       case 'equal':
         return this.OPERATORS.EQ;
+      case 'in':
+        return this.OPERATORS.IN;
       default:
         throw new NoMatchingOperatorError();
     }
@@ -79,6 +81,7 @@ function FiltersParser(modelSchema, timezone, options) {
       case 'equal':
       case 'before':
       case 'after':
+      case 'in':
         return value;
       case 'contains':
       case 'not_contains':
@@ -117,6 +120,8 @@ function FiltersParser(modelSchema, timezone, options) {
         return { [this.OPERATORS.NE]: null };
       case 'not_equal':
         return { [this.OPERATORS.NE]: value };
+      case 'in':
+        return { [this.OPERATORS.IN]: value };
       case 'blank':
         return isTextField ? {
           [this.OPERATORS.OR]: [{

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -764,6 +764,33 @@ const HasManyDissociator = require('../src/services/has-many-dissociator');
           });
         });
 
+        describe('with a "in" condition on a number field', () => {
+          it('should generate a valid SQL query', async () => {
+            expect.assertions(1);
+            const params = _.clone(paramsBaseList);
+            params.filters = JSON.stringify({
+              field: 'id',
+              operator: 'in',
+              value: [100],
+            });
+            const result = await new ResourcesGetter(models.user, sequelizeOptions, params)
+              .perform();
+            expect(result[0]).toHaveLength(1);
+          });
+
+          it('should return the records result', async () => {
+            expect.assertions(1);
+            const params = _.clone(paramsBaseCount);
+            params.filters = JSON.stringify({
+              field: 'id',
+              operator: 'in',
+              value: [100],
+            });
+            const count = await new ResourcesGetter(models.user, sequelizeOptions, params).count();
+            expect(count).toStrictEqual(1);
+          });
+        });
+
         describe('with a "is null" condition on a boolean field', () => {
           it('should generate a valid SQL query', async () => {
             expect.assertions(1);


### PR DESCRIPTION
The ability to use the IN operator with forest-express when using a custom filter

let ids = [1, 2, 3, 4, 5]
`{"field":"buyer:id","operator":"in","value": [${ids}]}`;