### PR TITLE
fix: :bug: fix a regression introduced by changes in the build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,5 +14,6 @@
   "plugins": [
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-transform-runtime",
+    "@babel/plugin-transform-arrow-functions",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/cli": "7.10.1",
     "@babel/core": "7.10.1",
     "@babel/plugin-proposal-optional-chaining": "7.10.1",
+    "@babel/plugin-transform-arrow-functions": "7.10.4",
     "@babel/plugin-transform-runtime": "7.10.1",
     "@babel/preset-env": "7.10.1",
     "@babel/register": "7.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz#ec5a5cf0eec925b66c60580328b122c01230a127"
   integrity sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==
 
+"@babel/helper-plugin-utils@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
+  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
+
 "@babel/helper-regex@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.10.1.tgz#021cf1a7ba99822f993222a001cc3fec83255b96"
@@ -676,6 +681,13 @@
   integrity sha512-hgA5RYkmZm8FTFT3yu2N9Bx7yVVOKYT6yEdXXo6j2JTm0wNxgqaGeQVaSHRjhfnQbX91DtjFB6McRFSlcJH3xQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
+
+"@babel/plugin-transform-arrow-functions@7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz#e22960d77e697c74f41c501d44d73dbf8a6a64cd"
+  integrity sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-arrow-functions@^7.10.1":
   version "7.10.1"


### PR DESCRIPTION
Arrow functions were no longer transformed to normal function after specifying the build target. As exported function are used with the new keyword in some context (even if they should not), this caused a crash when launching an agent.

Linked to CU-7rv8fc

There is a mismatch between what is exported by `forest-express-sequelize` and what is expected by `forest-express`:

- `forest-express-sequelize` exports a plain function
- `forest-express` uses it as a constructor

Which one is right in this case?

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
