### PR TITLE
fix: use `isPrimaryKey` instead of `undefined` primaryKey

### DIFF
--- a/src/adapters/sequelize.js
+++ b/src/adapters/sequelize.js
@@ -83,7 +83,7 @@ module.exports = (model, opts) => {
       }
 
       _.remove(fields, (field) =>
-        _.includes(fieldNamesToExclude, field.columnName) && !field.primaryKey);
+        _.includes(fieldNamesToExclude, field.columnName) && !field.isPrimaryKey);
 
       return {
         name: model.name,


### PR DESCRIPTION
`ApimapFieldBuilder` is returning a schema object with `isPrimariKey` attribute https://github.com/sliteteam/forest-express-sequelize/blob/a6b820348e9aa01b79d5659779c806fdf54e1adb/src/services/apimap-field-builder.js#L146

The sequelize schema adapter is using `primaryKey` attribute which is undefined https://github.com/ForestAdmin/forest-express-sequelize/blob/master/src/adapters/sequelize.js#L86

So every association of type `BelongsTo` which is also a primary key are discarded from the `.forestadmin-schema.json`.

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code