### PR TITLE
chore: revert "chore: mark versions older than the latest major - 3 as deprecated on npm"

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -51,26 +51,5 @@ module.exports = {
         packageName: 'forest-express-sequelize',
       }
     ],
-    [
-      "semantic-release-npm-deprecate-old-versions", {
-        "rules": [
-          { 
-            "rule": "supportLatest", 
-            "options": {
-              "numberOfMajorReleases": 3,
-              "numberOfMinorReleases": "all",
-              "numberOfPatchReleases": "all"
-            }
-          },
-          { 
-            "rule": "supportPreReleaseIfNotReleased", 
-            "options": {
-              "numberOfPreReleases": 1,
-            }
-          },
-          "deprecateAll"
-        ]
-      }
-    ]
   ],
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "onchange": "6.0.0",
     "pg": "8.4.2",
     "semantic-release": "17.3.0",
-    "semantic-release-npm-deprecate-old-versions": "1.1.0",
     "semantic-release-slack-bot": "1.6.2",
     "sequelize": "5.21.3",
     "sequelize-fixtures": "1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,21 +4092,6 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^4.0.3:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
-  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -9153,14 +9138,6 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-semantic-release-npm-deprecate-old-versions@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/semantic-release-npm-deprecate-old-versions/-/semantic-release-npm-deprecate-old-versions-1.1.0.tgz#b6b252b7e7c9eb6dde66784c579fdd86c9cadb74"
-  integrity sha512-gQKzKuIhPm4yjr1RCrB7iQmKkQCjbxfEut2dyTyBL15sGq9m5AD0GABD3705ivhtSBtrgsSvRf1B1pi1o47hTw==
-  dependencies:
-    execa "^4.0.3"
-    semver "^7.3.2"
 
 semantic-release-slack-bot@1.6.2:
   version "1.6.2"


### PR DESCRIPTION
Reverts ForestAdmin/forest-express-sequelize#592