### PR TITLE
refactor: rewrite has-many-getter as a subclass of resources-getter

### DIFF
--- a/src/services/has-many-getter.js
+++ b/src/services/has-many-getter.js
@@ -44,7 +44,7 @@ class HasManyGetter extends ResourcesGetter {
       parentOptions.limit = options.limit;
 
       // Order with the relation (https://github.com/sequelize/sequelize/issues/4553)
-      parentOptions.order = (options.order || []).map((o) => [associationName, ...o]);
+      parentOptions.order = (options.order || []).map((fields) => [associationName, ...fields]);
     }
 
     return parentOptions;

--- a/src/services/has-many-getter.js
+++ b/src/services/has-many-getter.js
@@ -1,124 +1,53 @@
-const _ = require('lodash');
-const Interface = require('forest-express');
-const orm = require('../utils/orm');
-const QueryBuilder = require('./query-builder');
-const SearchBuilder = require('./search-builder');
-const FiltersParser = require('./filters-parser');
-const PrimaryKeysManager = require('./primary-keys-manager');
-const extractRequestedFields = require('./requested-fields-extractor');
-const Operators = require('../utils/operators');
+import PrimaryKeysManager from './primary-keys-manager';
+import ResourcesGetter from './resources-getter';
 
-class HasManyGetter {
-  constructor(model, association, options, params) {
-    this.model = model;
-    this.association = association;
-    this.params = params;
-    this.queryBuilder = new QueryBuilder(model, options, params);
-    this.schema = Interface.Schemas.schemas[association.name];
-    [this.primaryKeyModel] = _.keys(model.primaryKeys);
-    this.operators = Operators.getInstance(options);
-    this.filtersParser = new FiltersParser(this.schema, params.timezone, options);
-    this.fieldNamesRequested = extractRequestedFields(
-      params.fields, association, Interface.Schemas.schemas,
-    );
-    this.searchBuilder = new SearchBuilder(
-      association,
-      options,
-      params,
-      this.fieldNamesRequested,
-    );
+class HasManyGetter extends ResourcesGetter {
+  constructor(model, association, lianaOptions, params) {
+    super(association, lianaOptions, params);
+
+    this._parentModel = model.unscoped();
   }
 
-  async buildWhereConditions({ associationName, search, filters }) {
-    const { AND } = this.operators;
-    const where = { [AND]: [] };
-
-    if (search) {
-      const searchCondition = this.searchBuilder.perform(associationName);
-      where[AND].push(searchCondition);
-    }
-
-
-    if (filters) {
-      const formattedFilters = await this.filtersParser.perform(filters);
-      where[AND].push(formattedFilters);
-    }
-
-    return where;
-  }
-
-  async findQuery(queryOptions) {
-    if (!queryOptions) { queryOptions = {}; }
-    const { associationName, recordId } = this.params;
-
-    const where = await this.buildWhereConditions(this.params);
-    const include = this.queryBuilder.getIncludes(this.association, this.fieldNamesRequested);
-
-    const record = await orm.findRecord(this.model, recordId, {
-      order: queryOptions.order,
-      subQuery: false,
-      offset: queryOptions.offset,
-      limit: queryOptions.limit,
-      // NOTICE: by default, all fields from the parent model
-      //         are retrieved, which can cause performance issues,
-      //         whereas we are only requesting the child model here
-      //         and we don't need the parent's attributes
-      attributes: [],
-      include: [{
-        model: this.association,
-        as: associationName,
-        scope: false,
-        required: false,
-        where,
-        include,
-      }],
-    });
-
-    return (record && record[associationName]) || [];
+  async _getRecords() {
+    const options = await this._buildQueryOptions();
+    const record = await this._parentModel.findOne(options);
+    return (record && record[this._params.associationName]) || [];
   }
 
   async count() {
-    const { associationName, recordId } = this.params;
-    const where = await this.buildWhereConditions(this.params);
-    const include = this.queryBuilder.getIncludes(this.association, this.fieldNamesRequested);
-
-    return this.model.count({
-      where: { [this.primaryKeyModel]: recordId },
-      include: [{
-        model: this.association,
-        as: associationName,
-        where,
-        required: true,
-        scope: false,
-        include,
-      }],
-    });
+    const options = await this._buildQueryOptions({ forCount: true });
+    return this._parentModel.count(options);
   }
 
-  async getRecords() {
-    const { associationName } = this.params;
+  async _buildQueryOptions(buildOptions = {}) {
+    const { associationName, recordId } = this._params;
+    const [model, options] = await super._buildQueryOptions({
+      ...buildOptions, tableAlias: associationName,
+    });
 
-    const queryOptions = {
-      order: this.queryBuilder.getOrder(associationName, this.schema),
-      offset: this.queryBuilder.getSkip(),
-      limit: this.queryBuilder.getLimit(),
+    const parentOptions = {
+      where: new PrimaryKeysManager(this._parentModel).getRecordsConditions([recordId]),
+      include: [{
+        model,
+        as: associationName,
+        scope: false,
+        required: !!buildOptions.forCount, // Why?
+        where: options.where,
+        include: options.include,
+      }],
     };
 
-    const records = await this.findQuery(queryOptions);
-    new PrimaryKeysManager(this.association).annotateRecords(records);
-    return records;
-  }
+    if (!buildOptions.forCount) {
+      parentOptions.subQuery = false; // Why?
+      parentOptions.attributes = []; // Don't fetch parent attributes (perf)
+      parentOptions.offset = options.offset;
+      parentOptions.limit = options.limit;
 
-  async perform() {
-    const records = await this.getRecords();
-
-    let fieldsSearched = null;
-
-    if (this.params.search) {
-      fieldsSearched = this.searchBuilder.getFieldsSearched();
+      // Order with the relation (https://github.com/sequelize/sequelize/issues/4553)
+      parentOptions.order = (options.order || []).map((o) => [associationName, ...o]);
     }
 
-    return [records, fieldsSearched];
+    return parentOptions;
   }
 }
 

--- a/test/services/query-builder.test.js
+++ b/test/services/query-builder.test.js
@@ -3,30 +3,6 @@ import Interface from 'forest-express';
 import QueryBuilder from '../../src/services/query-builder';
 
 describe('services > query-builder', () => {
-  describe('getOrder', () => {
-    const sequelizeOptions = { sequelize: Sequelize };
-    const model = { name: 'actor' };
-    Interface.Schemas = { schemas: { actor: { idField: 'id' } } };
-
-    it('should return null if there is no sort param', () => {
-      expect.assertions(1);
-      const order = new QueryBuilder(model, sequelizeOptions, {}).getOrder();
-      expect(order).toBeNull();
-    });
-
-    it('should return should set order ASC by default', () => {
-      expect.assertions(1);
-      const order = new QueryBuilder(model, sequelizeOptions, { sort: 'id' }).getOrder();
-      expect(order).toStrictEqual([['id', 'ASC']]);
-    });
-
-    it('should return should set order DESC if there is a minus sign', () => {
-      expect.assertions(1);
-      const order = new QueryBuilder(model, sequelizeOptions, { sort: '-id' }).getOrder();
-      expect(order).toStrictEqual([['id', 'DESC']]);
-    });
-  });
-
   describe('getIncludes', () => {
     ['HasOne', 'BelongsTo'].forEach((associationType) => {
       describe(`with a ${associationType} relationship`, () => {


### PR DESCRIPTION
diff-coverage is 100%
global coverage goes down because we're factorizing covered code.