### PR TITLE
feat(filters): add support for the `model.field IN array` filter condition

### DIFF
--- a/src/services/filters-parser.js
+++ b/src/services/filters-parser.js
@@ -93,6 +93,8 @@ function FiltersParser(modelSchema, timezone, options) {
         return { [this.OPERATORS.EQ]: value };
       case 'includes_all':
         return { [this.OPERATORS.CONTAINS]: value };
+      case 'in':
+        return { [this.OPERATORS.IN]: value };
       default:
         throw new NoMatchingOperatorError();
     }

--- a/test/databases.test.js
+++ b/test/databases.test.js
@@ -2588,6 +2588,39 @@ const HasManyDissociator = require('../src/services/has-many-dissociator');
           });
         });
 
+        describe('with a "in" condition on a number field', () => {
+          it('should generate a valid SQL query', async () => {
+            expect.assertions(1);
+
+            const { models, sequelizeOptions } = initializeSequelize();
+            const params = _.clone(paramsBaseList);
+            params.filters = JSON.stringify({
+              field: 'id',
+              operator: 'in',
+              value: [100, 101, 102],
+            });
+            const result = await new ResourcesGetter(models.user, sequelizeOptions, params)
+              .perform();
+            // Only users with ids 100 and 102 exist in fixtures
+            expect(result[0]).toHaveLength(2);
+          });
+
+          it('should return the records result', async () => {
+            expect.assertions(1);
+
+            const { models, sequelizeOptions } = initializeSequelize();
+            const params = _.clone(paramsBaseCount);
+            params.filters = JSON.stringify({
+              field: 'id',
+              operator: 'in',
+              value: [100, 101, 102],
+            });
+            const count = await new ResourcesGetter(models.user, sequelizeOptions, params).count();
+            // Only users with ids 100 and 102 exist in fixtures
+            expect(count).toStrictEqual(2);
+          });
+        });
+
         describe('with complex filters conditions', () => {
           const filters = JSON.stringify({
             aggregator: 'and',

--- a/test/services/filters-parser.test.js
+++ b/test/services/filters-parser.test.js
@@ -92,7 +92,7 @@ describe('services > filters-parser', () => {
 
     values.forEach((value) => {
       it(`should return the appropriate value (${typeof value})`, () => {
-        expect.assertions(14);
+        expect.assertions(15);
         expect(defaultFiltersParser.formatOperatorValue('starts_with', value)).toStrictEqual({ [OPERATORS.LIKE]: `${value}%` });
         expect(defaultFiltersParser.formatOperatorValue('ends_with', value)).toStrictEqual({ [OPERATORS.LIKE]: `%${value}` });
         expect(defaultFiltersParser.formatOperatorValue('contains', value)).toStrictEqual({ [OPERATORS.LIKE]: `%${value}%` });
@@ -113,6 +113,7 @@ describe('services > filters-parser', () => {
             [OPERATORS.EQ]: '',
           }],
         });
+        expect(defaultFiltersParser.formatOperatorValue('in', value)).toStrictEqual({ [OPERATORS.IN]: value });
       });
 
       it('should raise an error on unknown operator', () => {


### PR DESCRIPTION
Based this previous [PR](https://github.com/ForestAdmin/forest-express-sequelize/pull/490) and thus co-authored by @jirick1987

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Create automatic tests
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
