### PR TITLE
fix: regression when fetching has-many and not selecting any fields on a hasone/belongsto relation

### DIFF
--- a/src/services/has-many-getter.js
+++ b/src/services/has-many-getter.js
@@ -1,3 +1,4 @@
+import { pick } from 'lodash';
 import Operators from '../utils/operators';
 import QueryUtils from '../utils/query';
 import PrimaryKeysManager from './primary-keys-manager';
@@ -35,8 +36,7 @@ class HasManyGetter extends ResourcesGetter {
         as: associationName,
         scope: false,
         required: !!buildOptions.forCount, // Why?
-        where: options.where,
-        include: options.include,
+        ...pick(options, ['where', 'include']),
       }],
     });
 

--- a/test/databases.test.js
+++ b/test/databases.test.js
@@ -2957,6 +2957,34 @@ const HasManyDissociator = require('../src/services/has-many-dissociator');
         });
       });
 
+      describe('request on the has-many getter without relations', () => {
+        it('should generate a valid SQL query', async () => {
+          expect.assertions(1);
+          const { models, sequelizeOptions } = initializeSequelize();
+          const params = {
+            recordId: 100,
+            associationName: 'addresses',
+            fields: {
+              address: 'line,zipCode,city,country',
+            },
+            page: { number: '1', size: '20' },
+            timezone: 'Europe/Paris',
+          };
+          try {
+            await new HasManyGetter(
+              models.user,
+              models.address,
+              sequelizeOptions,
+              params,
+            )
+              .perform();
+            expect(true).toBeTrue();
+          } finally {
+            connectionManager.closeConnection();
+          }
+        });
+      });
+
       describe('request on the has-many-getter with a sort on an attribute', () => {
         it('should generate a valid SQL query', async () => {
           expect.assertions(1);


### PR DESCRIPTION
Fix:
https://community.forestadmin.com/t/unexpected-error-cannot-read-property-map-of-undefined-after-update-to-v7-8-0/2479/9

The bug was that when crafting sequelize queries, `include: undefined` is NOT equivalent to not setting the field.

@see https://github.com/sequelize/sequelize/blob/v5.15.1/lib/model.js#L704-L706
