### PR TITLE
fix(retrocompatibility): make test suite pass with sequelize@4.x

### DIFF
--- a/src/services/has-many-getter.js
+++ b/src/services/has-many-getter.js
@@ -1,6 +1,5 @@
 import { pick } from 'lodash';
-import Operators from '../utils/operators';
-import QueryUtils from '../utils/query';
+import SequelizeCompatibility from '../utils/sequelize-compatibility';
 import PrimaryKeysManager from './primary-keys-manager';
 import ResourcesGetter from './resources-getter';
 
@@ -23,13 +22,12 @@ class HasManyGetter extends ResourcesGetter {
   }
 
   async _buildQueryOptions(buildOptions = {}) {
-    const operators = Operators.getInstance({ Sequelize: this._parentModel.sequelize.constructor });
     const { associationName, recordId } = this._params;
     const [model, options] = await super._buildQueryOptions({
       ...buildOptions, tableAlias: associationName,
     });
 
-    const parentOptions = QueryUtils.bubbleWheresInPlace(operators, {
+    const parentOptions = SequelizeCompatibility.postProcess(this._parentModel, {
       where: new PrimaryKeysManager(this._parentModel).getRecordsConditions([recordId]),
       include: [{
         model,

--- a/src/services/pie-stat-getter.js
+++ b/src/services/pie-stat-getter.js
@@ -2,7 +2,7 @@ import { Schemas } from 'forest-express';
 import _ from 'lodash';
 import moment from 'moment';
 import { isMSSQL } from '../utils/database';
-import Orm, { isVersionLessThan4 } from '../utils/orm';
+import Orm, { isVersionLessThan } from '../utils/orm';
 import QueryOptions from './query-options';
 
 // NOTICE: These aliases are not camelcased to prevent issues with Sequelize.
@@ -10,7 +10,7 @@ const ALIAS_GROUP_BY = 'forest_alias_groupby';
 const ALIAS_AGGREGATE = 'forest_alias_aggregate';
 
 function PieStatGetter(model, params, options) {
-  const needsDateOnlyFormating = isVersionLessThan4(options.Sequelize);
+  const needsDateOnlyFormating = isVersionLessThan(options.Sequelize, '4.0.0');
 
   const schema = Schemas.schemas[model.name];
   let associationSplit;

--- a/src/services/query-options.js
+++ b/src/services/query-options.js
@@ -1,14 +1,15 @@
 import { logger, Schemas } from 'forest-express';
 import _ from 'lodash';
+import { isMSSQL } from '../utils/database';
 import Operators from '../utils/operators';
+import QueryUtils from '../utils/query';
+import SequelizeCompatibility from '../utils/sequelize-compatibility';
 import { ErrorHTTP422 } from './errors';
 import FiltersParser from './filters-parser';
 import LiveQueryChecker from './live-query-checker';
 import PrimaryKeysManager from './primary-keys-manager';
 import QueryBuilder from './query-builder';
 import SearchBuilder from './search-builder';
-import QueryUtils from '../utils/query';
-import { isMSSQL } from '../utils/database';
 
 /**
  * Sequelize query options generator which is configured using forest admin concepts (filters,
@@ -30,7 +31,7 @@ class QueryOptions {
       options.limit = this._limit;
     }
 
-    return options;
+    return SequelizeCompatibility.postProcess(this._model, options);
   }
 
   /**

--- a/src/services/value-stat-getter.js
+++ b/src/services/value-stat-getter.js
@@ -58,7 +58,8 @@ class ValueStatGetter {
       .unscoped()
       .aggregate(this._aggregateField, this._aggregateFunction, options);
 
-    return count ?? 0;
+    // sequelize@4 returns NaN, while sequelize@5+ returns null
+    return count || 0;
   }
 
   /**

--- a/src/utils/orm.js
+++ b/src/utils/orm.js
@@ -10,9 +10,9 @@ const getVersion = (sequelize) => {
   return null;
 };
 
-const isVersionLessThan4 = (sequelize) => {
+const isVersionLessThan = (sequelize, target) => {
   try {
-    return semver.lt(getVersion(sequelize), '4.0.0');
+    return semver.lt(getVersion(sequelize), target);
   } catch (error) {
     return true;
   }
@@ -36,7 +36,7 @@ const isUUID = (DataTypes, fieldType) =>
     || fieldType instanceof DataTypes.UUIDV4;
 
 exports.getVersion = getVersion;
-exports.isVersionLessThan4 = isVersionLessThan4;
+exports.isVersionLessThan = isVersionLessThan;
 exports.findRecord = findRecord;
 exports.getColumnName = getColumnName;
 exports.isUUID = isUUID;

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,5 +1,5 @@
-import Orm from './orm';
 import ObjectTools from './object-tools';
+import Orm from './orm';
 
 exports.getReferenceSchema = (schemas, modelSchema, associationName) => {
   const schemaField = modelSchema.fields.find((field) => field.field === associationName);
@@ -33,34 +33,3 @@ exports.mergeWhere = (operators, ...wheres) => wheres
   .reduce((where1, where2) => (ObjectTools.plainObjectsShareNoKeys(where1, where2)
     ? { ...where1, ...where2 }
     : { [operators.AND]: [where1, where2] }));
-
-/**
- * Extract all where conditions along the include tree, and bubbles them up to the top.
- * This allows to work around a sequelize quirk that cause nested 'where' to fail when they
- * refer to relation fields from an intermediary include (ie '$book.id$').
- *
- * This happens when forest admin filters on relations are used.
- *
- * @see https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level
- * @see https://github.com/ForestAdmin/forest-express-sequelize/blob/7d7ad0/src/services/filters-parser.js#L104
- */
-exports.bubbleWheresInPlace = (operators, options) => {
-  const parentInclude = options.include ?? [];
-
-  parentInclude.forEach((include) => {
-    exports.bubbleWheresInPlace(operators, include);
-
-    if (include.where) {
-      const newWhere = ObjectTools.mapKeysDeep(include.where, (key) => (
-        key[0] === '$' && key[key.length - 1] === '$'
-          ? `$${include.as}.${key.substring(1)}`
-          : `$${include.as}.${key}$`
-      ));
-
-      options.where = exports.mergeWhere(operators, options.where, newWhere);
-      delete include.where;
-    }
-  });
-
-  return options;
-};

--- a/src/utils/sequelize-compatibility.js
+++ b/src/utils/sequelize-compatibility.js
@@ -1,0 +1,150 @@
+import ObjectTools from './object-tools';
+import Operators from './operators';
+import { isVersionLessThan } from './orm';
+import QueryUtils from './query';
+
+/**
+ * Extract all where conditions along the include tree, and bubbles them up to the top in-place.
+ * This allows to work around a sequelize quirk that cause nested 'where' to fail when they
+ * refer to relation fields from an intermediary include (ie '$book.id$').
+ *
+ * This happens when forest admin filters on relations are used.
+ *
+ * @see https://sequelize.org/master/manual/eager-loading.html#complex-where-clauses-at-the-top-level
+ * @see https://github.com/ForestAdmin/forest-express-sequelize/blob/7d7ad0/src/services/filters-parser.js#L104
+ */
+function bubbleWheresInPlace(operators, options) {
+  const parentIncludeList = options.include ?? [];
+
+  parentIncludeList.forEach((include) => {
+    bubbleWheresInPlace(operators, include);
+
+    if (include.where) {
+      const newWhere = ObjectTools.mapKeysDeep(include.where, (key) => (
+        key[0] === '$' && key[key.length - 1] === '$'
+          ? `$${include.as}.${key.substring(1)}`
+          : `$${include.as}.${key}$`
+      ));
+
+      options.where = QueryUtils.mergeWhere(operators, options.where, newWhere);
+      delete include.where;
+    }
+  });
+}
+
+/**
+ * Includes can be expressed in different ways in sequelize, which is inconvenient to
+ * remove duplicate associations.
+ * This convert all valid ways to perform eager loading into [{model: X, as: 'x'}].
+ *
+ * This is necessary as we have no control over which way customer use when writing SmartFields
+ * search handlers.
+ *
+ * Among those:
+ * - { include: [Book] }
+ * - { include: [{ association: 'book' }] }
+ * - { include: ['book'] }
+ * - { include: [[{ as: 'book' }]] }
+ * - { include: [[{ model: Book }]] }
+ */
+function normalizeInclude(model, include) {
+  if (include.sequelize) {
+    return {
+      model: include,
+      as: Object
+        .keys(model.associations)
+        .find((association) => model.associations[association].target.name === include.name),
+    };
+  }
+
+  if (typeof include === 'string' && model.associations[include]) {
+    return { as: include, model: model.associations[include].target };
+  }
+
+  if (typeof include === 'object') {
+    if (typeof include.association === 'string' && model.associations[include.association]) {
+      include.as = include.association;
+      delete include.association;
+    }
+
+    if (typeof include.as === 'string' && !include.model && model.associations[include.as]) {
+      const includeModel = model.associations[include.as].target;
+      include.model = includeModel;
+    }
+
+    if (include.model && !include.as) {
+      include.as = Object
+        .keys(model.associations)
+        .find((association) => model.associations[association].target.name === include.model.name);
+    }
+  }
+
+  // Recurse
+  if (include.include) {
+    include.include = include.include.map(
+      (childInclude) => normalizeInclude(include.model, childInclude),
+    );
+  }
+
+  return include;
+}
+
+/**
+ * Remove duplications in a queryOption.include array in-place.
+ * Using multiple times the same association yields invalid SQL when using sequelize <= 4.x
+ */
+function removeDuplicateAssociations(model, includeList) {
+  // Remove duplicates
+  includeList.sort((include1, include2) => (include1.as < include2.as ? -1 : 1));
+  for (let i = 1; i < includeList.length; i += 1) {
+    if (includeList[i - 1].as === includeList[i].as) {
+      const newInclude = { ...includeList[i - 1], ...includeList[i] };
+
+      if (includeList[i - 1].attributes && includeList[i].attributes) {
+        // Keep 'attributes' only when defined on both sides.
+        newInclude.attributes = [...new Set([
+          ...includeList[i - 1].attributes,
+          ...includeList[i].attributes,
+        ])];
+      } else {
+        delete newInclude.attributes;
+      }
+
+      if (includeList[i - 1].include || includeList[i].include) {
+        newInclude.include = [
+          ...(includeList[i - 1].include ?? []),
+          ...(includeList[i].include ?? []),
+        ];
+      }
+
+      includeList[i - 1] = newInclude;
+      includeList.splice(i, 1);
+      i -= 1;
+    }
+  }
+
+  // Recurse
+  includeList.forEach((include) => {
+    if (include.include) {
+      const association = model.associations[include.as];
+      removeDuplicateAssociations(association.target, include.include);
+    }
+  });
+}
+
+exports.postProcess = (model, rawOptions) => {
+  if (!rawOptions.include) return rawOptions;
+
+  const options = rawOptions;
+  const operators = Operators.getInstance({ Sequelize: model.sequelize.constructor });
+
+  if (isVersionLessThan(model.sequelize.constructor, '5.0.0')) {
+    options.include = options.include.map((include) => normalizeInclude(model, include));
+    bubbleWheresInPlace(operators, options);
+    removeDuplicateAssociations(model, options.include);
+  } else {
+    bubbleWheresInPlace(operators, options);
+  }
+
+  return options;
+};

--- a/src/utils/sequelize-compatibility.js
+++ b/src/utils/sequelize-compatibility.js
@@ -105,7 +105,7 @@ function removeDuplicateAssociations(model, includeList) {
         newInclude.attributes = [...new Set([
           ...includeList[i - 1].attributes,
           ...includeList[i].attributes,
-        ])];
+        ])].sort();
       } else {
         delete newInclude.attributes;
       }

--- a/test/services/has-many-getter.test.js
+++ b/test/services/has-many-getter.test.js
@@ -16,18 +16,19 @@ describe('services > HasManyGetter', () => {
 
   describe('_buildQueryOptions', () => {
     const options = { tableAlias: 'users' };
-    const model = {
-      name: 'cars',
-      unscoped: () => model,
-      sequelize: sequelizePostgres.connection,
-      primaryKeys: { id: {} },
-    };
-    const association = {
+    const UserModel = {
       name: 'users',
       rawAttributes: [{ field: 'name', type: 'String' }],
       sequelize: sequelizePostgres.connection,
-      unscoped: () => association,
+      unscoped: () => UserModel,
       associations: { },
+    };
+    const CarModel = {
+      name: 'cars',
+      unscoped: () => CarModel,
+      sequelize: sequelizePostgres.connection,
+      primaryKeys: { id: {} },
+      associations: { users: { target: UserModel } },
     };
     Interface.Schemas = {
       schemas: {
@@ -40,7 +41,7 @@ describe('services > HasManyGetter', () => {
       it('should build an empty where condition', async () => {
         expect.assertions(1);
 
-        const hasManyGetter = new HasManyGetter(model, association, lianaOptions, baseParams);
+        const hasManyGetter = new HasManyGetter(CarModel, UserModel, lianaOptions, baseParams);
         const queryOptions = await hasManyGetter._buildQueryOptions(options);
 
         expect(queryOptions.where).toStrictEqual({ id: 1 });
@@ -55,7 +56,7 @@ describe('services > HasManyGetter', () => {
           ...baseParams,
           filters: '{ "field": "id", "operator": "greater_than", "value": 1 }',
         };
-        const hasManyGetter = new HasManyGetter(model, association, lianaOptions, params);
+        const hasManyGetter = new HasManyGetter(CarModel, UserModel, lianaOptions, params);
         const queryOptions = await hasManyGetter._buildQueryOptions(options);
 
         expect(queryOptions.where).toStrictEqual({
@@ -70,7 +71,7 @@ describe('services > HasManyGetter', () => {
         expect.assertions(1);
 
         const params = { ...baseParams, search: 'test' };
-        const hasManyGetter = new HasManyGetter(model, association, lianaOptions, params);
+        const hasManyGetter = new HasManyGetter(CarModel, UserModel, lianaOptions, params);
         const queryOptions = await hasManyGetter._buildQueryOptions(options);
 
         expect(queryOptions.where).toStrictEqual({
@@ -95,7 +96,7 @@ describe('services > HasManyGetter', () => {
           filters: '{ "field": "id", "operator": "greater_than", "value": 1 }',
           search: 'test',
         };
-        const hasManyGetter = new HasManyGetter(model, association, lianaOptions, params);
+        const hasManyGetter = new HasManyGetter(CarModel, UserModel, lianaOptions, params);
         const queryOptions = await hasManyGetter._buildQueryOptions(options);
 
         expect(queryOptions.where).toStrictEqual({

--- a/test/utils/query.test.js
+++ b/test/utils/query.test.js
@@ -1,5 +1,5 @@
 const { Sequelize } = require('sequelize');
-const { getReferenceField, mergeWhere, bubbleWheresInPlace } = require('../../src/utils/query');
+const { getReferenceField, mergeWhere } = require('../../src/utils/query');
 
 const operators = { AND: '$and' };
 
@@ -67,48 +67,6 @@ describe('utils > query', () => {
           { id: 1 },
           Sequelize.literal('FALSE'),
         ],
-      });
-    });
-  });
-
-  describe('bubbleWheresInPlace', () => {
-    it('work in a simple case', () => {
-      expect.assertions(1);
-
-      const options = bubbleWheresInPlace(operators, {
-        include: [
-          { as: 'submodel', where: { id: 1 } },
-        ],
-        where: {
-          id: 1,
-        },
-      });
-
-      expect(options).toStrictEqual({
-        include: [
-          { as: 'submodel' },
-        ],
-        where: {
-          id: 1,
-          '$submodel.id$': 1,
-        },
-      });
-    });
-
-    it('should work when the parent have no where condition', () => {
-      expect.assertions(1);
-
-      const options = bubbleWheresInPlace(operators, {
-        include: [
-          { as: 'submodel', where: { id: 1 } },
-        ],
-      });
-
-      expect(options).toStrictEqual({
-        include: [
-          { as: 'submodel' },
-        ],
-        where: { '$submodel.id$': 1 },
       });
     });
   });

--- a/test/utils/sequelize-compatibility.test.js
+++ b/test/utils/sequelize-compatibility.test.js
@@ -1,0 +1,207 @@
+const { postProcess } = require('../../src/utils/sequelize-compatibility');
+
+const sequelize = { constructor: { version: '4.44.4' } };
+const Model = {
+  sequelize,
+  name: 'model',
+  associations: {
+    submodelAlias: {
+      target: {
+        sequelize,
+        name: 'submodel',
+        associations: {
+          subsubmodel1Alias: {
+            target: {
+              sequelize,
+              name: 'subsubmodel2',
+              associations: {},
+            },
+          },
+          subsubmodel2Alias: {
+            target: {
+              sequelize,
+              name: 'subsubmodel1',
+              associations: {},
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const SubModel = Model.associations.submodelAlias.target;
+const SubSubModel1 = SubModel.associations.subsubmodel1Alias.target;
+const SubSubModel2 = SubModel.associations.subsubmodel2Alias.target;
+
+
+describe('utils > sequelize-compatibility', () => {
+  describe('postProcess -> normalizeInclude', () => {
+    it('should work when using the {model, as} syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: [{ model: SubModel, as: 'submodelAlias' }] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should work when using the {model} syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: [{ model: SubModel }] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should work when using the {as} syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: [{ as: 'submodelAlias' }] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should work when using the {association} syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: [{ association: 'submodelAlias' }] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should work when using the string syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: ['submodelAlias'] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should work when using the Model syntax', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, { include: [SubModel] });
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+  });
+
+  describe('postProcess -> bubbleWhere', () => {
+    it('work in a simple case', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [{ as: 'submodelAlias', where: { id: 1 } }],
+        where: { id: 1 },
+      });
+
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+        where: { id: 1, '$submodelAlias.id$': 1 },
+      });
+    });
+
+    it('should work when the parent have no where condition', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [{ as: 'submodelAlias', where: { id: 1 } }],
+      });
+
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+        where: { '$submodelAlias.id$': 1 },
+      });
+    });
+
+    it('should work when multiple include have where conditions', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [
+          SubModel,
+          'submodelAlias',
+          { as: 'submodelAlias', where: { id: 1 } },
+          { association: 'submodelAlias', where: { title: 'Title' } },
+          { model: SubModel, where: { subTitle: 'subTitle' } },
+        ],
+        where: {
+          '$submodelAlias.rating$': 34,
+        },
+      });
+
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+        where: {
+          '$submodelAlias.id$': 1,
+          '$submodelAlias.title$': 'Title',
+          '$submodelAlias.subTitle$': 'subTitle',
+          '$submodelAlias.rating$': 34,
+        },
+      });
+    });
+
+    it('should work recursively', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [
+          SubModel,
+          'submodelAlias',
+          {
+            as: 'submodelAlias',
+            include: [
+              {
+                as: 'subsubmodel1Alias',
+                model: SubSubModel1,
+                where: { subsubTitle: 'subsubtitle1' },
+              },
+            ],
+            where: { id: 1 },
+          },
+          { association: 'submodelAlias', where: { title: 'Title' } },
+          {
+            model: SubModel,
+            include: [
+              {
+                model: SubSubModel2,
+                where: { subsubTitle: 'subsubtitle2' },
+              },
+            ],
+            where: { subTitle: 'subTitle' },
+          },
+        ],
+        where: {
+          '$submodelAlias.rating$': 34,
+        },
+      });
+
+      expect(options).toStrictEqual({
+        include: [
+          {
+            as: 'submodelAlias',
+            model: SubModel,
+            include: [
+              { as: 'subsubmodel1Alias', model: SubSubModel1 },
+              { as: 'subsubmodel2Alias', model: SubSubModel2 },
+            ],
+          },
+        ],
+        where: {
+          '$submodelAlias.id$': 1,
+          '$submodelAlias.title$': 'Title',
+          '$submodelAlias.subTitle$': 'subTitle',
+          '$submodelAlias.rating$': 34,
+          '$submodelAlias.subsubmodel1Alias.subsubTitle$': 'subsubtitle1',
+          '$submodelAlias.subsubmodel2Alias.subsubTitle$': 'subsubtitle2',
+        },
+      });
+    });
+  });
+});

--- a/test/utils/sequelize-compatibility.test.js
+++ b/test/utils/sequelize-compatibility.test.js
@@ -37,7 +37,7 @@ const SubSubModel2 = SubModel.associations.subsubmodel2Alias.target;
 
 describe('utils > sequelize-compatibility', () => {
   describe('postProcess -> normalizeInclude', () => {
-    it('should work when using the {model, as} syntax', () => {
+    it('should rewrite the include when using the {model, as} syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: [{ model: SubModel, as: 'submodelAlias' }] });
@@ -46,7 +46,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when using the {model} syntax', () => {
+    it('should rewrite the include when using the {model} syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: [{ model: SubModel }] });
@@ -55,7 +55,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when using the {as} syntax', () => {
+    it('should rewrite the include when using the {as} syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: [{ as: 'submodelAlias' }] });
@@ -64,7 +64,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when using the {association} syntax', () => {
+    it('should rewrite the include when using the {association} syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: [{ association: 'submodelAlias' }] });
@@ -73,7 +73,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when using the string syntax', () => {
+    it('should rewrite the include when using the string syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: ['submodelAlias'] });
@@ -82,7 +82,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when using the Model syntax', () => {
+    it('should rewrite the include when using the Model syntax', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, { include: [SubModel] });
@@ -92,8 +92,8 @@ describe('utils > sequelize-compatibility', () => {
     });
   });
 
-  describe('postProcess -> bubbleWhere', () => {
-    it('work in a simple case', () => {
+  describe('postProcess', () => {
+    it('bubble where conditions', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, {
@@ -107,7 +107,37 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when the parent have no where condition', () => {
+    it('shoud add attributes when both sides are defined', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [
+          { as: 'submodelAlias', attributes: ['id'] },
+          { as: 'submodelAlias', attributes: ['name'] },
+        ],
+      });
+
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel, attributes: ['id', 'name'] }],
+      });
+    });
+
+    it('shoud drop attributes when either side is undefined', () => {
+      expect.assertions(1);
+
+      const options = postProcess(Model, {
+        include: [
+          { as: 'submodelAlias', attributes: ['id'] },
+          { as: 'submodelAlias' },
+        ],
+      });
+
+      expect(options).toStrictEqual({
+        include: [{ as: 'submodelAlias', model: SubModel }],
+      });
+    });
+
+    it('should not crash if the root where conditions are undefined', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, {
@@ -120,7 +150,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work when multiple include have where conditions', () => {
+    it('should merge includes when there are duplicates (for sequelize < 5)', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, {
@@ -147,7 +177,7 @@ describe('utils > sequelize-compatibility', () => {
       });
     });
 
-    it('should work recursively', () => {
+    it('should do all of the above recursively', () => {
       expect.assertions(1);
 
       const options = postProcess(Model, {


### PR DESCRIPTION
Fix retrocompatibility with sequelize 4.

The issue in the ticket is due to the fact than in Sequelize 4, it is illegal to join the same relation twice.
This happens in smart field cutom search, when customers inject "include" into the query options

```
{
  // illegal in sequelize@4, OK in sequelize@5 and 6
  include: [
     { as: 'something', model: Something },
     { as: 'something', model: Something }
  ]
```