### PR TITLE
chore(workflow): bump setup-node and fix minimal node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false # GITHUB_TOKEN must not be set for the semantic release
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 12.13.0
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'


### PR DESCRIPTION
### Description
> is blocking https://github.com/ForestAdmin/forest-express-sequelize/pull/867

Bump trusted external action from v1 to v2 (actions/setup-node)
Fix minimal node version to 12.x (the one already used in the deploy step)