### PR TITLE
chore: change postgres testing port to allow testing in local environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ postgres :
   image : postgres:9.4.5
   container_name : forest_express_sequelize_postgres
   ports :
-    - "5436:5432"
+    - "5437:5432"
   environment:
     - POSTGRES_DB=forest-express-sequelize-test
     - POSTGRES_USER=forest

--- a/test/databases.js
+++ b/test/databases.js
@@ -42,7 +42,7 @@ class ConnectionManager {
  * @type {Record<string, ConnectionManager>}
  */
 module.exports = {
-  sequelizePostgres: new ConnectionManager('Postgresql 9.4', 'postgres://forest:secret@localhost:5436/forest-express-sequelize-test'),
+  sequelizePostgres: new ConnectionManager('Postgresql 9.4', 'postgres://forest:secret@localhost:5437/forest-express-sequelize-test'),
   sequelizeMySQLMin: new ConnectionManager('MySQL 5.6', 'mysql://forest:secret@localhost:8998/forest-express-sequelize-test'),
   sequelizeMySQLMax: new ConnectionManager('MySQL 8.0', 'mysql://forest:secret@localhost:8999/forest-express-sequelize-test'),
 };

--- a/test/services/apimap-field-builder.test.js
+++ b/test/services/apimap-field-builder.test.js
@@ -8,7 +8,7 @@ const databaseOptions = {
 };
 
 const sequelize = new Sequelize(
-  'postgres://forest:secret@localhost:5436/forest-express-sequelize-test',
+  'postgres://forest:secret@localhost:5437/forest-express-sequelize-test',
   databaseOptions,
 );
 


### PR DESCRIPTION
## Definition of Done

Changing the Postgres testing port to allow developers test the project with his development environment (eg: `forest_postgres_renderings` turn on 5436)

### General

- [X] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [X] Test manually the implemented changes
- [X] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [X] Ensure that Types have been updated according to your changes (if needed)

### Security

- [X] Consider the security impact of the changes made
