### PR TITLE
fix: add isSortable to SmartFieldOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -256,6 +256,7 @@ export interface SmartFieldOptions {
   description?: string;
   type: FieldType;
   isFilterable?: boolean;
+  isSortable?: boolean;
   isReadOnly?: boolean;
   isRequired?: boolean;
   reference?: string;


### PR DESCRIPTION
## Definition of Done
I added `isSortable` to type `SmartFieldOptions`. It is a valid param for a field, and should be accepted by typescript (check it out here: https://github.com/ForestAdmin/forest-express/blob/main/src/services/apimap-fields-formater.js).

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [x] Consider the security impact of the changes mad