### PR TITLE
fix: add isSortable in SmartFieldOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -276,6 +276,7 @@ export interface SmartFieldOptions {
   isFilterable?: boolean;
   isReadOnly?: boolean;
   isRequired?: boolean;
+  isSortable?: boolean;
   reference?: string;
   enums?: FieldEnumsType;
   defaultValue?: any;


### PR DESCRIPTION
Hey,

If I trust your [docs](https://docs.forestadmin.com/documentation/reference-guide/smart-fields/smart-field-examples/sort-by-smart-field#smart-field-definition)
It missing isSortable property in SmartFieldOptions

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [x] Consider the security impact of the changes made
