### PR TITLE
fix(type): add "isSortable" to SmartFieldOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -274,6 +274,7 @@ export interface SmartFieldOptions {
   description?: string;
   type: FieldType;
   isFilterable?: boolean;
+  isSortable?: boolean;
   isReadOnly?: boolean;
   isRequired?: boolean;
   reference?: string;


### PR DESCRIPTION
According to doc: https://docs.forestadmin.com/documentation/reference-guide/smart-fields/smart-field-examples/sort-by-smart-field, smart field option should allow to set property `isSortable` as optional boolean

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [x] Consider the security impact of the changes made
