### PR TITLE
fix(smart-field): smart-field search use returned query

### DIFF
--- a/src/services/search-builder.js
+++ b/src/services/search-builder.js
@@ -74,16 +74,17 @@ function SearchBuilder(model, opts, params, fieldNamesRequested) {
     // Retrocompatibility: customers which implement search on smart fields are expected to
     // inject their conditions at .where[Op.and][0][Op.or].push(searchCondition)
     // https://docs.forestadmin.com/documentation/reference-guide/fields/create-and-manage-smart-fields
-    const query = {
+    let query = {
       include: [],
       where: { [OPERATORS.AND]: [this.perform(associationName)] },
     };
 
     const fieldsWithSearch = schema.fields.filter((field) => field.search);
+
     await Promise.all(
       fieldsWithSearch.map(async (field) => {
         try {
-          await field.search(query, params.search);
+          query = await field.search(query, params.search);
         } catch (error) {
           const errorMessage = `Cannot search properly on Smart Field ${field.field}: `;
           Interface.logger.error(errorMessage, error);


### PR DESCRIPTION
## Definition of Done

### General

Actually smart-field search use mutation on `query` params instead of use returned query value as defined in [type definition](https://github.com/ForestAdmin/forest-express-sequelize/blob/75ba32f197a8856e1788809f13dd6e54a2231f62/types/index.d.ts#L254) and in [doc](https://docs.forestadmin.com/documentation/reference-guide/smart-fields#searching-sorting-and-filtering-on-a-smart-field).

My proposal is to use the returned value, but keep mind it will break the search of people using only mutation. If you want to keep the mutation, update doc](https://docs.forestadmin.com/documentation/reference-guide/smart-fields#searching-sorting-and-filtering-on-a-smart-field) to remove the `return query` and in  [type definition](https://github.com/ForestAdmin/forest-express-sequelize/blob/75ba32f197a8856e1788809f13dd6e54a2231f62/types/index.d.ts#L254) change return to `void`

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [ ] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made
