### PR TITLE
fix(typing): add missing expressParentApp to LianaOptions types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Application, NextFunction, Request, RequestHandler, Response } from 'express';
+import { Application, NextFunction, Request, RequestHandler, Response, Router } from 'express';
 import * as Sequelize from 'sequelize';
 
 // Everything related to Forest initialization
@@ -12,6 +12,7 @@ export interface LianaOptions {
   excludedModels?: string[];
   configDir?: string;
   schemaDir?: string;
+  expressParentApp?: Router;
 }
 
 export function init(options: LianaOptions): Promise<Application>;


### PR DESCRIPTION
## Definition of Done
Fixes https://github.com/ForestAdmin/forest-express-sequelize/issues/1084

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [x] Ensure that Types have been updated according to your changes (if needed)

### Security

- [x] Consider the security impact of the changes made
