### PR TITLE
fix: add baseUrl to SmartActionOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -332,6 +332,7 @@ export interface SmartActionOptions {
   fields?: SmartActionField[];
   download?: boolean;
   endpoint?: string;
+  baseUrl?: string;
   httpMethod?: string;
   hooks?: SmartActionHooks;
 }


### PR DESCRIPTION
## Definition of Done

### General
The `SmartActionOptions` types was missing the props `baseUrl` available in the [forest-express](https://github.com/ForestAdmin/forest-express/blob/ea3dbeb5d71cb6e64ace960bd28d2202bd15067f/src/serializers/schema.js#L56) package.

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)
- [ ] Ensure that Types have been updated according to your changes (if needed)

### Security

- [ ] Consider the security impact of the changes made
