### PR TITLE
fix(resources-remover): support scopes targeting relation fields

### DIFF
--- a/src/services/resources-remover.js
+++ b/src/services/resources-remover.js
@@ -1,4 +1,6 @@
 import { scopeManager } from 'forest-express';
+import _ from 'lodash';
+import Operators from '../utils/operators';
 import { InvalidParameterError } from './errors';
 import QueryOptions from './query-options';
 
@@ -22,7 +24,45 @@ class ResourcesRemover {
     await queryOptions.filterByIds(this._ids);
     await queryOptions.filterByConditionTree(scopeFilters, timezone);
 
-    return this._model.destroy(queryOptions.sequelizeOptions);
+    const options = queryOptions.sequelizeOptions;
+
+    // `Model.destroy` ignores `include`, so a where clause referencing a
+    // joined column (e.g. `$product.id$`) produces invalid SQL. Resolve the
+    // matching primary keys with a SELECT first, then delete by PK.
+    if (options.include?.length) {
+      return this._destroyByPrimaryKey(options);
+    }
+
+    return this._model.destroy(options);
+  }
+
+  async _destroyByPrimaryKey(options) {
+    const pkAttributes = Object.keys(this._model.primaryKeys);
+    const matches = await this._model.findAll({
+      attributes: pkAttributes,
+      where: options.where,
+      include: options.include,
+    });
+
+    if (matches.length === 0) return 0;
+
+    return this._model.destroy({
+      where: ResourcesRemover._buildPrimaryKeyWhere(this._model, pkAttributes, matches),
+    });
+  }
+
+  static _buildPrimaryKeyWhere(model, pkAttributes, records) {
+    if (pkAttributes.length === 1) {
+      const [pk] = pkAttributes;
+      return { [pk]: records.map((record) => record.get(pk)) };
+    }
+
+    const OPERATORS = Operators.getInstance({ Sequelize: model.sequelize.constructor });
+    return {
+      [OPERATORS.OR]: records.map(
+        (record) => _.fromPairs(pkAttributes.map((pk) => [pk, record.get(pk)])),
+      ),
+    };
   }
 }
 

--- a/test/services/resources-remover.test.js
+++ b/test/services/resources-remover.test.js
@@ -1,4 +1,4 @@
-import { scopeManager } from 'forest-express';
+import Interface, { scopeManager } from 'forest-express';
 import Sequelize, { Op } from 'sequelize';
 import { InvalidParameterError } from '../../src/services/errors';
 import ResourcesRemover from '../../src/services/resources-remover';
@@ -83,6 +83,118 @@ describe('services > resources-remover', () => {
         await new ResourcesRemover(ActorFilm, params, ['1|2', '3|4'], user).perform();
         spy.mockRestore();
       });
+    });
+  });
+
+  describe('when scope targets a relation field', () => {
+    const scope = { field: 'film:id', operator: 'present', value: null };
+
+    const setup = () => {
+      const { Actor, Film, ActorFilm } = buildModelMock('postgres');
+      Actor.belongsTo(Film);
+
+      Interface.Schemas.schemas = {
+        actor: {
+          name: 'actor',
+          fields: [
+            { field: 'id', type: 'Number' },
+            { field: 'film', reference: 'film.id' },
+          ],
+          primaryKeys: ['id'],
+          idField: 'id',
+        },
+        ActorFilem: {
+          name: 'ActorFilem',
+          fields: [
+            { field: 'actorId', type: 'Number' },
+            { field: 'filmId', type: 'Number' },
+            { field: 'film', reference: 'film.id' },
+          ],
+          primaryKeys: ['actorId', 'filmId'],
+          idField: 'actorId|filmId',
+        },
+        film: {
+          name: 'film',
+          fields: [{ field: 'id', type: 'Number' }],
+          primaryKeys: ['id'],
+          idField: 'id',
+        },
+      };
+
+      const scopeSpy = jest.spyOn(scopeManager, 'getScopeForUser').mockResolvedValue(scope);
+      const restore = () => {
+        scopeSpy.mockRestore();
+        Interface.Schemas.schemas = {};
+      };
+
+      return { Actor, ActorFilm, restore };
+    };
+
+    it('should resolve PKs via findAll, then destroy by Op.in for single-PK models', async () => {
+      expect.assertions(4);
+
+      const { Actor, restore } = setup();
+      const findAllSpy = jest.spyOn(Actor, 'findAll').mockResolvedValue([
+        { get: () => 7 },
+        { get: () => 42 },
+      ]);
+      const destroySpy = jest.spyOn(Actor, 'destroy').mockResolvedValue(2);
+
+      await new ResourcesRemover(Actor, params, ['7', '42'], user).perform();
+
+      expect(findAllSpy).toHaveBeenCalledTimes(1);
+      expect(findAllSpy.mock.calls[0][0].include).toStrictEqual(
+        expect.arrayContaining([expect.objectContaining({ as: 'film' })]),
+      );
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+      expect(destroySpy).toHaveBeenCalledWith({ where: { id: [7, 42] } });
+
+      findAllSpy.mockRestore();
+      destroySpy.mockRestore();
+      restore();
+    });
+
+    it('should destroy by Op.or for composite-PK models', async () => {
+      expect.assertions(1);
+
+      const { ActorFilm, restore } = setup();
+      const findAllSpy = jest.spyOn(ActorFilm, 'findAll').mockResolvedValue([
+        { get: (key) => ({ actorId: 1, filmId: 2 }[key]) },
+        { get: (key) => ({ actorId: 3, filmId: 4 }[key]) },
+      ]);
+      const destroySpy = jest.spyOn(ActorFilm, 'destroy').mockResolvedValue(2);
+
+      await new ResourcesRemover(ActorFilm, params, ['1|2', '3|4'], user).perform();
+
+      expect(destroySpy).toHaveBeenCalledWith({
+        where: {
+          [Op.or]: [
+            { actorId: 1, filmId: 2 },
+            { actorId: 3, filmId: 4 },
+          ],
+        },
+      });
+
+      findAllSpy.mockRestore();
+      destroySpy.mockRestore();
+      restore();
+    });
+
+    it('should not call destroy when no record matches the scope', async () => {
+      expect.assertions(2);
+
+      const { ActorFilm, restore } = setup();
+      const findAllSpy = jest.spyOn(ActorFilm, 'findAll').mockResolvedValue([]);
+      const destroySpy = jest.spyOn(ActorFilm, 'destroy');
+
+      const removed = await new ResourcesRemover(ActorFilm, params, ['1|2'], user).perform();
+
+      expect(destroySpy).not.toHaveBeenCalled();
+      expect(removed).toBe(0);
+
+      findAllSpy.mockRestore();
+      destroySpy.mockRestore();
+      restore();
     });
   });
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `ResourcesRemover` to support scopes targeting relation fields
- When `QueryOptions` produces an `include` (e.g. a scope filtered on a related model's column), `perform()` now runs a `findAll` to resolve matching primary keys and then calls `destroy` with those PKs, instead of passing `include` directly to `Model.destroy`.
- Adds `_destroyByPrimaryKey` to handle the select-then-delete flow, and `_buildPrimaryKeyWhere` to construct the correct `WHERE` clause for both single and composite primary keys.
- If no records match the scope, `destroy` is skipped and `perform()` returns `0`.
- Behavioral Change: deletion paths that previously passed `include` directly to `Model.destroy` (which Sequelize silently ignores) now correctly filter and delete only matching rows.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb24d05.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->