### PR TITLE
chore(deps): bump forest-express to 10.8.0 [force release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/runtime": "7.15.4",
     "bluebird": "2.9.25",
     "core-js": "3.6.5",
-    "forest-express": "10.7.0",
+    "forest-express": "10.8.0",
     "http-errors": "1.6.1",
     "lodash": "4.17.21",
     "moment": "2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,10 +5484,10 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-forest-express@10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.7.0.tgz#4eeb5043f8beca10a2141718e64b668c76fc7409"
-  integrity sha512-5/c9Rdu4GNZhTz8vJ/wBt58vMhHIDbfPRCYnPk6Y1Oq/Vug8faGZUMoBbaLY9oX35zHGl+vOlmag7MxDutTtIA==
+forest-express@10.8.0:
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.8.0.tgz#88210e32b0c525e63e1d65a6fe364a211a05a165"
+  integrity sha512-t5CPdfQ6cUsMaizbdPGY8FgOx4s/Ldl4zH7yKoJxtcqDaNrOdBBXf7H40eRlOeEHmvr/LnY6b+9hkLy8nT2zLQ==
   dependencies:
     "@babel/runtime" "7.19.0"
     "@forestadmin/context" "1.42.11"


### PR DESCRIPTION
## What
Bumps `forest-express` `10.7.0` → `10.8.0` (same as the forest-express-mongoose bump #1128).

## Why
Brings into forest-express-sequelize the latest forest-express release:
- **10.8.0** — `feat(agent): forward workflow executor routes generically` ([#1060](https://github.com/ForestAdmin/forest-express/pull/1060), PRD-567)

The agent now forwards any verb/sub-path under `/_internal/workflow-executions/*` to the executor `/runs` namespace with a single catch-all, so adding an executor route no longer requires an agent change. Minor/additive — no breaking change.

## Verification
- `yarn.lock` diff scoped to the `forest-express` entry only (no transitive changes).
- Unit tests green; the dialect integration suite runs in CI (old DB image tags lack arm64 manifests, so the matrix isn't runnable on Apple Silicon locally).

`[force release]` in the subject to publish a patch (a plain `chore` doesn't trigger semantic-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)