### PR TITLE
chore(deps): bump forest-express to 10.9.0 [force release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/runtime": "7.15.4",
     "bluebird": "2.9.25",
     "core-js": "3.6.5",
-    "forest-express": "10.8.0",
+    "forest-express": "10.9.0",
     "http-errors": "1.6.1",
     "lodash": "4.17.21",
     "moment": "2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,10 +5484,10 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-forest-express@10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.8.0.tgz#88210e32b0c525e63e1d65a6fe364a211a05a165"
-  integrity sha512-t5CPdfQ6cUsMaizbdPGY8FgOx4s/Ldl4zH7yKoJxtcqDaNrOdBBXf7H40eRlOeEHmvr/LnY6b+9hkLy8nT2zLQ==
+forest-express@10.9.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.9.0.tgz#d7768f6aadc806ee934f515cffc97dbb869b1429"
+  integrity sha512-9u4Ezb/YvwcAhPdZXAWAnNpg7PUqlmmLaP+FmH/fmJS0vwu8TfGOBkR1CMY3glwkVv1Pio2HhupQOIrEA+nEGw==
   dependencies:
     "@babel/runtime" "7.19.0"
     "@forestadmin/context" "1.42.11"


### PR DESCRIPTION
## What
Bumps `forest-express` `10.8.0` → `10.9.0` (same as the forest-express-mongoose bump).

## Why
Brings in the latest forest-express release:
- **10.9.0** — `feat(agent): forward any executor route generically` ([#1061](https://github.com/ForestAdmin/forest-express/pull/1061), PRD-567)

The agent now forwards `/_internal/executor/*` verbatim to the executor (single catch-all, all verbs), so a new executor route needs no agent change. Minor/additive — no breaking change.

## Verification
- `yarn.lock` diff scoped to the `forest-express` entry only.
- Validated by CI.

`[force release]` in the subject to publish a patch (a plain `chore` doesn't trigger semantic-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `forest-express` dependency from 10.8.0 to 10.9.0
> Updates `forest-express` in [package.json](https://github.com/ForestAdmin/forest-express-sequelize/pull/1146/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from 10.8.0 to 10.9.0 with corresponding lockfile changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22f46f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->