### PR TITLE
chore(deps): bump forest-express to 10.9.2 [force release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/runtime": "7.15.4",
     "bluebird": "2.9.25",
     "core-js": "3.6.5",
-    "forest-express": "10.9.1",
+    "forest-express": "10.9.2",
     "http-errors": "1.6.1",
     "lodash": "4.17.21",
     "moment": "2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,10 +5484,10 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-forest-express@10.9.1:
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.9.1.tgz#a7dcdb0b32ad114f9eb281eb19da1a8646ca4397"
-  integrity sha512-HFjXDq9ODUjcD0KeSyj9EDOHw4r6BEwBgywN66NQhwlT3VJPZa4buvDq/0MhSxEicpo4NoOKT477Olxo/OaROg==
+forest-express@10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/forest-express/-/forest-express-10.9.2.tgz#3781dbb0431fda178c08ac7c1c84af4e93a3c5d8"
+  integrity sha512-oMgAlBx08ekD9XBiTWcajJYDb3fenDXlj/GJZ/nHhU8lx7EHsAkaSyRWp8CDleTyrbmVzWH0AcTZcXFPt1psjA==
   dependencies:
     "@babel/runtime" "7.19.0"
     "@forestadmin/context" "1.42.11"


### PR DESCRIPTION
Bumps `forest-express` `10.9.1` → `10.9.2`, which ships the IP-whitelist `BlockList` optimization ([forest-express#1063](https://github.com/ForestAdmin/forest-express/pull/1063), PRD-798). No API change — a per-request `net.BlockList` rebuild becomes per-refresh.

## Verification
- `yarn install` regenerated the lockfile (`forest-express@10.9.2`); diff limited to `package.json` + `yarn.lock`.
- `yarn lint`: 0 errors (pre-existing complexity warnings only).
- DB-backed test suite (postgres + MySQL 5.6/8.0 + MariaDB) left to CI — the legacy `mysql:5.6` image has no native arm64 build, so the full multi-DB suite isn't runnable on Apple Silicon locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `forest-express` dependency from 10.9.1 to 10.9.2
> Updates the `forest-express` version in [package.json](https://github.com/ForestAdmin/forest-express-sequelize/pull/1148/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and regenerates the lockfile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 098af2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->